### PR TITLE
allowing Assay to take extra fields

### DIFF
--- a/src/pg2_dataset/primitives/setting.py
+++ b/src/pg2_dataset/primitives/setting.py
@@ -39,7 +39,7 @@ class Metadata(BaseModel):
     xref: str | None = None
 
 
-class Assay(BaseModel):
+class Assay(BaseModel, extra="allow"):
     name: str | None = None
     description: str | None = None
     features: list[str] = Field(default_factory=list)


### PR DESCRIPTION
Allowing Assay to take extra field, as means to get rid of the old `manifest.json` in pg2 projects.