### PR TITLE
Require motivation instead of pre-requisite in feature request

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -14,8 +14,8 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: Requirements
-      description: The requirement to be met for closing this issue. 
+      label: Motivation
+      description: Explain why this functionality needs changing.
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
# Changes

- Require motivation instead of pre-requisite in feature request

## Motivation

We prefer the motivation, while pre-requisites was a repitition for summary