### PR TITLE
Update comment on using TemporaryDirectory

### DIFF
--- a/src/pg2_dataset/dataset.py
+++ b/src/pg2_dataset/dataset.py
@@ -159,8 +159,10 @@ class Dataset(BaseModel):
             ValueError: If multiple manifest files are found in the ZIP archive.
             FileNotFoundError: If no manifest file is found in the ZIP archive.
         """
-        # We are using a temporary directory to extract the ZIP archive
-        # because we want to avoid IO to disk in the main directory.
+        # While a SE practice is to avoid IO to disk where possible,
+        # we use a temporary directory here to extract the dataset archive as
+        # Pydantic expects the file path to exist, while still hiding the IO
+        # from the users.
         with TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             with ZipFile(path, "r") as zip_file:
@@ -294,11 +296,12 @@ class Dataset(BaseModel):
         if isinstance(path, str):  # User-friendly interface to support str
             path = Path(path)
         path = path or Path.cwd()
-        # While we prefer to avoid IO to disk, TemporaryDirectory is used for
-        # convenience because it unifies the `:method:dump` signatures to write
-        # to a directory.
+        # While a SE practice is to avoid IO to disk where possible,
+        # we use a temporary directory here to extract the dataset archive as
+        # Pydantic expects the file path to exist, while still hiding the IO
+        # from the users.
         with TemporaryDirectory() as temp_dir:
-            # TemporaryDirectory returns a string, we prefer a Path object.
-            temp_dir = Path(temp_dir)
-            archive_path = self._create_archive(path, temporary_directory=temp_dir)
+            archive_path = self._create_archive(
+                path, temporary_directory=Path(temp_dir)
+            )
         return archive_path


### PR DESCRIPTION
# Changes

Progresses #108

Comment why we use `TemporaryDirectory`, which is against our SE practice.

# Checklist

- [x] I broke the PR down so that it contains a reasonable amount of changes for an effective review
- [x] I performed a self-review of my code. Amongst other things, I have commented my code in hard-to-understand areas.
- [x] I made corresponding changes to the documentation
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I accounted for dependent changes to be merged and published in downstream modules
