### PR TITLE
make sequence and target feature name hidden

### DIFF
--- a/src/pg2_dataset/assay.py
+++ b/src/pg2_dataset/assay.py
@@ -124,11 +124,19 @@ class Assay:
     description: str | None = None
     """The description of the assay."""
 
-    sequence_feature_name: str = "sequence"
+    _sequence_feature_name: str = "sequence"
     """The sequence feature name in the assay records."""
 
-    target_feature_name: str = "target"
+    _target_feature_name: str = "target"
     """The target feature name in the assay records."""
+
+    @property
+    def sequence_feature_name(self) -> str:
+        return self._sequence_feature_name
+
+    @property
+    def target_feature_name(self) -> str:
+        return self._target_feature_name
 
     @classmethod
     def from_manifest_section(cls, section: AssayManifestSection) -> "Assay":

--- a/tests/test_assays.py
+++ b/tests/test_assays.py
@@ -145,8 +145,8 @@ def test_assay_dump(tmp_path: Path) -> None:
     assay = Assay(
         name="assay",
         records=[("F1I", 1.56), ("F1L", 2.0)],
-        sequence_feature_name="sequence",
-        target_feature_name="target",
+        _sequence_feature_name="sequence",
+        _target_feature_name="target",
     )
     dumped_path = assay.dump(path=tmp_path, format=AssayFormat.CSV)
     assert dumped_path == tmp_path / "assay.csv"
@@ -193,14 +193,14 @@ def test_dataset_with_dump_assays(tmp_path: Path) -> None:
     assay1 = Assay(
         name="assay1",
         records=[("F1I", 1.56), ("F1L", 2.0)],
-        sequence_feature_name="sequence",
-        target_feature_name="target",
+        _sequence_feature_name="sequence",
+        _target_feature_name="target",
     )
     assay2 = Assay(
         name="assay2",
         records=[("F2I", 1.0), ("F2L", 3.0)],
-        sequence_feature_name="sequence",
-        target_feature_name="target",
+        _sequence_feature_name="sequence",
+        _target_feature_name="target",
     )
     dataset = Dataset(
         name="test_dataset",
@@ -223,8 +223,8 @@ def test_dataset_instance_from_dump_assays(tmp_path: Path) -> None:
     assay1 = Assay(
         name="assay1",
         records=[("F1I", 1.56), ("F1L", 2.0)],
-        sequence_feature_name="sequence",
-        target_feature_name="target",
+        _sequence_feature_name="sequence",
+        _target_feature_name="target",
     )
     dataset = Dataset(
         name="test_dataset",


### PR DESCRIPTION
# Changes

Resolves #230 

Added `underscore` prefix for `Assay.sequence_feature_name` and `Assay.target_feature_name`.

# Checklist

- [x] I broke the PR down so that it contains a reasonable amount of changes for an effective review
- [x] I performed a self-review of my code. Amongst other things, I have commented my code in hard-to-understand areas.
- [ ] I made corresponding changes to the documentation
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I accounted for dependent changes to be merged and published in downstream modules
