### PR TITLE
Fix the data generator test with duplicates

### DIFF
--- a/src/proteingym/base/data_generators.py
+++ b/src/proteingym/base/data_generators.py
@@ -112,7 +112,7 @@ def charge_ladder_dataset(n_rows: int = 200, seq_len: int = 20) -> pl.DataFrame:
     parent = _generate_sequence(seq_len)
 
     sequences = set()
-    for _ in iter(lambda: len(sequences) < n_rows, False):
+    while len(sequences) < n_rows:
         sequences.add(charge_mutations(parent, random.randint(0, seq_len)))
 
     charge = [peptide_charge(seq) for seq in sequences]


### PR DESCRIPTION
# Changes

Since data generators can randomly generate duplicate sequences, the total number of generated sequences, bound by the `n-rows`, can be less than `n-rows`.

# Checklist

- [x] I broke the PR down so that it contains a reasonable amount of changes for an effective review
- [x] I performed a self-review of my code. Amongst other things, I have commented my code in hard-to-understand areas.
- [ ] I made corresponding changes to the documentation
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I accounted for dependent changes to be merged and published in downstream modules
