### PR TITLE
fix: bunch of typos and unformatted md tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,6 @@ This dataset is stored in `example_data/NEIME_2019` and contains the following:
 
 For a full overview of available data see the following table:
 
-|      | Dataset name | Link to website    | Relative path to manifest                              |
-| :--- | :----------- | :----------------- | :----------------------------------------------------- |
-| 1.   | NEIME2019    | www.proteingym.org | [example_data/neime_2019.toml](example_data/neime_2019.toml) |
+|    | Dataset name | Link to website    | Relative path to manifest                                    |
+|:---|:-------------|:-------------------|:-------------------------------------------------------------|
+| 1. | NEIME2019    | www.proteingym.org | [example_data/neime_2019.toml](example_data/neime_2019.toml) |

--- a/docs/decisions/0001-record-architecture-decisions.md
+++ b/docs/decisions/0001-record-architecture-decisions.md
@@ -32,10 +32,10 @@ We will use Architecture Decision Records, as [described by Michael Nygard](http
 ## Decision matrix
 
 | Option                              | Clarity | Traceability | Collaboration | Simplicity | Low barrier to entry |
-| ----------------------------------- | ------- | ------------ | ------------- | ---------- | -------------------- |
-| Markdown file in git                | High    | High         | High          | Medium     | High                  |
-| Previous option with dedicated tool | High    | High         | High          | High       | Medium                |
-| Wiki                                | High    | Medium       | Medium        | Low        | Low                   |
+|-------------------------------------|---------|--------------|---------------|------------|----------------------|
+| Markdown file in git                | High    | High         | High          | Medium     | High                 |
+| Previous option with dedicated tool | High    | High         | High          | High       | Medium               |
+| Wiki                                | High    | Medium       | Medium        | Low        | Low                  |
 
 [adr-tools](https://github.com/npryce/adr-tools) is chosen as dedicated tool
 option to automate handling ADRs.

--- a/docs/decisions/0002-user-facing-and-programmaticlly-used-manifest.md
+++ b/docs/decisions/0002-user-facing-and-programmaticlly-used-manifest.md
@@ -33,7 +33,7 @@ Furthermore, this package can augment the metadata in the external manifest with
 runtime metadata, like creation time, to create the metadata for the internal
 manifest.
 
-Currently we have an external user-facing manifest only. If we reuse that
+Currently, we have an external user-facing manifest only. If we reuse that
 within the dataset archive, then it is likely to become inaccurate when
 archiving the dataset. 
 
@@ -45,7 +45,7 @@ Not just because of efficiency, but also because access to the bucket might be
 unavailable at this time
 
 Additionally, a user needs to open the dataset archive to quickly reference the
-manifest (from a text editor) while we want users to only use the arhive 
+manifest (from a text editor) while we want users to only use the archive 
 through our package. Therefore, it is better to ship the (external)
 manifest **next to** the persisted dataset instead **within** .
 
@@ -76,7 +76,7 @@ archive to indicate it should not be edited by users.
 ## Decision matrix
 
 | Option                     | Accuracy          | Reusability | Quick reference                                                                          | Avoids access internals         |
-| -------------------------- | ----------------- | ----------- | ---------------------------------------------------------------------------------------- | ------------------------------- |
+|----------------------------|-------------------|-------------|------------------------------------------------------------------------------------------|---------------------------------|
 | No separation              | Low (see example) | High        | Low: when part of the dataset archive <br> High when shipped next to the dataset archive | Correlates with quick reference |
 | External and internal      | High              | High        | High: requires shipping next to the dataset archive                                      | high                            |
 | Additional internal medium | High              | Low         | High                                                                                     | High                            |
@@ -87,7 +87,7 @@ reusing manifest logic.
 ## Naming drivers
 
 The following drivers motivate the choice in naming.
-1. Accuracy: Accuracetly describes the manifest's purpose and how it is used.
+1. Accuracy: Accurately describes the manifest's purpose and how it is used.
 2. User-friendliness: The manifest should be easy to understand and use for
    users, while also being suitable for programmatic access.
 3. Verbosity: The manifest should not be overly verbose while still
@@ -102,7 +102,7 @@ The following drivers motivate the choice in naming.
 ## Naming Decision Matrix
 
 | Approach                       | Accuracy | User-friendliness | Verbosity |
-| ------------------------------ | -------- | ----------------- | --------- |
+|--------------------------------|----------|-------------------|-----------|
 | External / internal            | Medium   | Medium            | Medium    |
 | \<nothing\> / archive          | High     | High              | Medium    |
 | User-facing / Programmatically | High     | Low               | High      |
@@ -126,7 +126,7 @@ We accept that it is less verbosity over user-friendliness.
 ## File Name Decision Matrix
 
 | Option                  | Clarity | Consistency | Simplicity |
-| ----------------------- | ------- | ----------- | ---------- |
+|-------------------------|---------|-------------|------------|
 | `manifest.toml`         | Medium  | High        | High       |
 | `_manifest.toml`        | Medium  | Medium      | Medium     |
 | `manifest.lock`         | High    | Medium      | High       |

--- a/docs/decisions/0003-pydantic-usage.md
+++ b/docs/decisions/0003-pydantic-usage.md
@@ -49,7 +49,7 @@ Use Pydantic:
 ## Decision matrix
 
 | Option                   | Aligns with Pydantic's use | Use Pydantic features | Fail early | Avoid overuse |
-| ------------------------ | -------------------------- | --------------------- | ---------- | ------------- |
+|--------------------------|----------------------------|-----------------------|------------|---------------|
 | All data classes         | Low                        | High                  | High       | Low           |
 | `Manifest`               | High                       | Low                   | High       | High          |
 | `Manifest` and `Dataset` | High                       | Medium                | High       | High          |

--- a/docs/decisions/0004-dataset-archive.md
+++ b/docs/decisions/0004-dataset-archive.md
@@ -39,7 +39,7 @@ supported.
 ## Decision matrix
 
 | Option | User-friendly | Preserve info | Windows | Free license |
-| ------ | ------------- | ------------- | ------- | ------------ |
+|--------|---------------|---------------|---------|--------------|
 | ZIP    | High          | High          | High    | High         |
 | TAR.GZ | Medium        | High          | Medium  | High         |
 
@@ -78,7 +78,7 @@ The chosen archive file extension is `.pgdata`.
 ### Decision matrix for archive file extension
 
 | Option      | Branding | Avoid internals | Context                                                    | User-friendly |
-| ----------- | -------- | --------------- | ---------------------------------------------------------- | ------------- |
+|-------------|----------|-----------------|------------------------------------------------------------|---------------|
 | .zip        | Low      | High            | Low                                                        | High          |
 | .proteingym | High     | High            | Medium* The bigger context not just `proteingym-base` repo | Medium        |
 | .pgdata     | High     | High            | High* The context is clearly defined as protein datasets   | High          |

--- a/docs/decisions/0005-dataset-list.md
+++ b/docs/decisions/0005-dataset-list.md
@@ -25,9 +25,9 @@ There are two phases of filtering here:
   * Simple fields: `name=NEIME_2019`
   * Nested fields: `assay_conditions.name=PH`
   * Multiple conditions: `name=NEIME_2019&assay_conditions.name=PH`
-  * Multiple choises: `assay_conditions.name=PH,T` or `assay_conditions.name=PH&assay_conditions.name=T`
+  * Multiple choices: `assay_conditions.name=PH,T` or `assay_conditions.name=PH&assay_conditions.name=T`
 
-* The second is the [Dataset](../../src/pg2_dataset/dataset.py) object itself, namely `class Dataset(BaseModel)`:
+* The second is the [Dataset](../../src/proteingym/base/dataset.py) object itself, namely `class Dataset(BaseModel)`:
   * Simple fields: `name`, `description`, etc...
   * Nested fields: `assays`, `sequences`, `structures`, `msas`, etc... of which they are also a list to loop over, which will lead to extra CPU computations.
 
@@ -52,17 +52,17 @@ To choose which tool to use, our decisions are based on the following considerat
 ### 1. Whether to use an existing tool to parse and query `Dataset` object or build it ourselves. 
 * Both `JMESPath` and `jq` support the JSON data query, and both are CLI tools and have their corresponding Python package: [jmespath.py
 ](https://github.com/jmespath/jmespath.py) and [jq.py](https://github.com/mwilliamson/jq.py), meaning we can either use them in CLI or integrate them inside our `proteingym-base` Python package. 
-* Besides, by using these two tools, we can parse both the query params and the serialized `Dataset` object, wherease `urllib` can only parse the query params. To parse `Dataset`, we need to implement the logic ourselves which is non-trivial.
+* Besides, by using these two tools, we can parse both the query params and the serialized `Dataset` object, whereas `urllib` can only parse the query params. To parse `Dataset`, we need to implement the logic ourselves which is non-trivial.
 * The downsides of using these two tools are that they only support the JSON format, and we need to ensure the `Dataset` object can be serialized to JSON. Unluckily, `Bio.Seq.Seq` , `Bio.PDB.Structure`, `Bio.Align.MultipleSeqAlignment`  can't be serialized because they lack custom `JSONEncoder`, thus we need to rely on their `__str__` method to convert any non-serializable fields to their string representations.
 
 ### 2. Whether to parse and query `Dataset` inside our `proteingym-base` Python package or outside it in CLI. 
 * If we query it in CLI, then the command can be chained like proteingym-base list <path-to-your-dataset(s)> --format json | jq 'map(select(.name == "NEIME_2019"))'` using `jq`, instead of `proteingym-base list <path-to-your-dataset(s)> --query "name=NEIME_2019" --format json`, which is much simpler.
 * For the memory and performance characteristics of using `jq` or `JMESPath` in CLI to parse serialized `Dataset`, the comparison is shown in the following table:
   
-  | Tool     | Memory Usage                  | Processing                         |
-  | -------- | ----------------------------- | ---------------------------------- |
-  | jq       | Loads entire JSON into memory | [Stream-capable](https://jqlang.org/manual/#streaming) for some operations |
-  | JMESPath | Loads entire JSON into memory | In-memory processing               |
+| Tool     | Memory Usage                  | Processing                                                                 |
+|----------|-------------------------------|----------------------------------------------------------------------------|
+| jq       | Loads entire JSON into memory | [Stream-capable](https://jqlang.org/manual/#streaming) for some operations |
+| JMESPath | Loads entire JSON into memory | In-memory processing                                                       |
 
 * Based on [this jq benchmark](https://github.com/jqlang/jq/wiki/X---Experimental-Benchmarks), we see that `jq` handles moderate-sized datasets (54-181MB) quite well, compared to `gojq` (Go implementation), `rq` (Rust implementation). So we infer that given 1000 datasets (likely much smaller total size), processing should be very fast under seconds. Especially with `--stream`, it can reduce memory usage from 223MB to 1.3MB for the same operation.
 
@@ -77,7 +77,7 @@ There are several tools to parse the query params and the `Dataset` object, we t
 ## Decision matrix
 
 | Option   | Robustness                                               | Simplicity                  | Performance |
-| -------- | -------------------------------------------------------- | --------------------------- | ----------- |
+|----------|----------------------------------------------------------|-----------------------------|-------------|
 | JMESPath | High                                                     | Medium                      | Medium      |
 | jq       | High                                                     | Medium                      | High        |
 | urllib   | Low (We need to implement `Dataset` selection in Python) | High (Only in query params) | Unknown     |

--- a/docs/decisions/0006-model-validation.md
+++ b/docs/decisions/0006-model-validation.md
@@ -7,10 +7,10 @@ Status: Accepted
 
 There are two roles in a model benchmarking system:
 * Model provider: They either provide a model with a GitHub repo, a distribution package or a Docker image, or only share its API for a remote call. To validate a model to see if it can be integrated in the `proteingym` universe, they want to have an easy-to-use tool to sanity check their models quickly for a feeling of confidence.
-* Model benchmarker: They need a uniform API to call each model to get the same format of result in return, so they can compare them on a equal basis. Since they need to validate all models, they want a tool to call these models, while models are running in a self-contained execution environent.
+* Model benchmarker: They need a uniform API to call each model to get the same format of result in return, so they can compare them on an equal basis. Since they need to validate all models, they want a tool to call these models, while models are running in a self-contained execution environment.
 
 In order for the benchmark to work for a variety of models, we need to validate if these models conform to a standard. Examples of validation checks include:
-- [x] If they have the model card defined as expected, so we can load the model's hyperparamters.
+- [x] If they have the model card defined as expected, so we can load the model's hyperparameters.
 - [x] If they have the mandatory entrypoint, with expected input and output.
 
 Given the above considerations, we will first set out to build a tool for model providers to let them do a self-check quickly.
@@ -23,13 +23,13 @@ Currently, we use the [Option 2: Install `proteingym-base` as a dev dependency a
 
 The decision drivers are based on the following constraints, since they cover the majority of models.
 
-| Contraint | Type |
-| --------- | ---- |
-| The model is implemented in Python | Required |
-| The model provides its source code | Required |
-| The model project has a [src layout](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/) | Required |
-| The model exposes its entrypoints by CLI |  Nice to have |
-| The model is containerised which comes with its Dockerfile | Nice to have |
+| Constraint                                                                                                          | Type         |
+|---------------------------------------------------------------------------------------------------------------------|--------------|
+| The model is implemented in Python                                                                                  | Required     |
+| The model provides its source code                                                                                  | Required     |
+| The model project has a [src layout](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/) | Required     |
+| The model exposes its entrypoints by CLI                                                                            | Nice to have |
+| The model is containerised which comes with its Dockerfile                                                          | Nice to have |
 
 Thus, we come to the following drivers:
 
@@ -65,10 +65,10 @@ $ proteingym-base validate .
 
 ## Decision matrix
 
-| Option | Least dependencies | Work across platforms | No hardcoded paths and names | Least assumptions | Robustness | Insightfulness |
-|:-------|:------------------:|:---------------------:|:----------------------------:|:-----------------:|:----------:|:----------:|
-| Docker |                    | :white_check_mark:    | :white_check_mark:           |                   | :white_check_mark: | :white_check_mark: |
-| proteingym-base CLI | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Option              | Least dependencies | Work across platforms | No hardcoded paths and names | Least assumptions  |     Robustness     |   Insightfulness   |
+|:--------------------|:------------------:|:---------------------:|:----------------------------:|:------------------:|:------------------:|:------------------:|
+| Docker              |                    |  :white_check_mark:   |      :white_check_mark:      |                    | :white_check_mark: | :white_check_mark: |
+| proteingym-base CLI | :white_check_mark: |  :white_check_mark:   |      :white_check_mark:      | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 ## Consequences
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -7,12 +7,12 @@ The manifest defines how a [dataset](data_model.md) is constructed.
 The following capabilities have been identified:
 
 | Capability           | Kind           | Motivation                                                |
-| -------------------- | -------------- | --------------------------------------------------------- |
+|----------------------|----------------|-----------------------------------------------------------|
 | Primitive data types | Functional     | For data representation, like `int`, `bool` and `string`. |
 | Lists                | Functional     | For organizing data entries.                              |
 | Maps                 | Functional     | For organizing data entries.                              |
 | Human readable       | Non-functional | To facilitate understanding and editing directly.         |
-| Machine readable     | Non-functional | To facilitate programatical reading and parsing.          |
+| Machine readable     | Non-functional | To facilitate programmatically reading and parsing.       |
 | Version              | Non-functional | For schema evolution.                                     |
 | Dataset metadata     | Domain         | A place to define metadata, like name and description.    |
 | Path                 | Domain         | To reference data stored on file system.                  |
@@ -21,7 +21,7 @@ The following capabilities have been identified:
 Additionally, we defined:
 
 | Kind           | Description                                                                                                     |
-| -------------- | --------------------------------------------------------------------------------------------------------------- |
+|----------------|-----------------------------------------------------------------------------------------------------------------|
 | Functional     | The capability is directly related to the dataset's functionality and is essential for its operation            |
 | Non-functional | The capability is not directly related to the dataset's functionality but enhances usability or maintainability |
 | Domain         | The capability is specific to the domain of the dataset, such as biological data types.                         |
@@ -33,18 +33,18 @@ human-readable data serialization language. Below tables motivate the coice of
 TOML as the medium for the manifest.
 
 | Criteria           | Minimum | Motivation                                          |
-| ------------------ | ------- | --------------------------------------------------- |
+|--------------------|---------|-----------------------------------------------------|
 | Covers requirement | Yes     | The medium should cover the criteria                |
 | Text based         | No      | Works well with line-diffs in source control (git). |
 | Industry standard  | No      | Easier for user to adopt.                           |
 
 | Minimum criteria | Description                    |
-| ---------------- | ------------------------------ |
+|------------------|--------------------------------|
 | Yes              | The criteria is **required**.  |
 | No               | The criteria is **preferred**. |
 
 | Medium | Covers criteria | Text based | Industry standard |
-| ------ | --------------- | ---------- | ----------------- |
+|--------|-----------------|------------|-------------------|
 | TOML   | Yes             | Yes        | Yes               |
 
 ## Schema
@@ -110,7 +110,7 @@ The top-level of the manifest contains the dataset metadata and references to
 the protein data types.
 
 | **Field**         | **Type**              | **Required** | **Default** | **Description**                                                                                                                                                                                                                                                                                                          |
-| ----------------- | --------------------- | ------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|-------------------|-----------------------|--------------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `version`         | `string`              | Yes          | N/A         | The version of the manifest schema. The version follows the semantic versioning format: `<major>.<minor>.<patch>`. A major version change indicates breaking changes, while a minor version change indicates backward-compatible additions or changes. A patch version change indicates bug fixes or minor improvements. |
 | `name`            | `string`              | Yes          | N/A         | The name of the dataset.                                                                                                                                                                                                                                                                                                 |
 | `description`     | `string \| None`      | No           | `None`      | A brief description of the dataset.                                                                                                                                                                                                                                                                                      |
@@ -126,7 +126,7 @@ the protein data types.
 The assay variables section contains a list of assay variables defined in the dataset. E.g., the pH a certain assay was run at, or the round of engineering that an assay belonged to.
 
 | **Field**     | **Type**                              | **Required** | **Default** | **Description**            |
-| ------------- | ------------------------------------- | ------------ | ----------- | -------------------------- |
+|---------------|---------------------------------------|--------------|-------------|----------------------------|
 | `name`        | `string`                              | Yes          | N/A         | The assay variable name    |
 | `description` | `string \| None`                      | No           | `None`      | A brief description.       |
 | `unit`        | `string \| None`                      | No           | `None`      | The unit of measurement.   |
@@ -137,7 +137,7 @@ The assay variables section contains a list of assay variables defined in the da
 The assay targets section contains a list of assay targets defined in the dataset. E.g., the target measured in a certain assay, like binding affinity or stability.
 
 | **Field**     | **Type**                              | **Required** | **Default** | **Description**          |
-| ------------- | ------------------------------------- | ------------ | ----------- | ------------------------ |
+|---------------|---------------------------------------|--------------|-------------|--------------------------|
 | `name`        | `string`                              | Yes          | N/A         | The assay target name    |
 | `description` | `string \| None`                      | No           | `None`      | A brief description.     |
 | `unit`        | `string \| None`                      | No           | `None`      | The unit of measurement. |
@@ -148,7 +148,7 @@ The assay targets section contains a list of assay targets defined in the datase
 The assays section contains a list of assays included in the dataset.
 
 | **Field**           | **Type**         | **Required** | **Default**  | **Description**                                                          |
-| ------------------- | ---------------- | ------------ | ------------ | ------------------------------------------------------------------------ |
+|---------------------|------------------|--------------|--------------|--------------------------------------------------------------------------|
 | `name`              | `string`         | No           | `None`       | The name of the assay.                                                   |
 | `path`              | `string`         | Yes          | N/A          | The path to the assay data file. Supported extensions: `.csv`.           |
 | `targets`           | `dict[str, str]` | Yes          | N/A          | The map of target names given in manifest to feature names in the assay. |
@@ -178,7 +178,7 @@ sequence = "mutated_sequence"
 The sequences section contains a list of sequences included in the dataset.
 
 | **Field**  | **Type**         | **Required** | **Default** | **Description**                                                                                                                                                     |
-| ---------- | ---------------- | ------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|------------|------------------|--------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `path`     | `string`         | Yes          | N/A         | The path to the sequence data file or directory. In case of directories, all files within the directory will be included. Supported extensions: `.fasta`, `.fastq`. |
 | `alphabet` | `string`         | Yes          | N/A         | The alphabet of the sequence (e.g., "DNA", "RNA", "AA").                                                                                                            |
 | `type`     | `string` \| None | No           | None        | The type of the sequence (e.g., "wild_type", "starting_sequence", "engineered_sequence").                                                                           |
@@ -188,7 +188,7 @@ The sequences section contains a list of sequences included in the dataset.
 The structures section contains a list of structures included in the dataset.
 
 | **Field** | **Type** | **Required** | **Default** | **Description**                                                                                                                                                           |
-| --------- | -------- | ------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-----------|----------|--------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `path`    | `string` | Yes          | N/A         | The path to the structure data file or directory. In case of directories, all files within the directory will be included. Supported extensions: `.pdb`, `.cif`, `.bcif`. |
 
 ### MSAs
@@ -196,7 +196,7 @@ The structures section contains a list of structures included in the dataset.
 The MSAs section contains a list of multiple sequence alignments included in the dataset.
 
 | **Field**            | **Type**              | **Required** | **Default** | **Description**                                                                                                                                            |
-| -------------------- | --------------------- | ------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|----------------------|-----------------------|--------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `path`               | `string`              | Yes          | N/A         | The path to the MSA data file or directory. In case of directories, all files within the directory will be included. Supported extensions: `.a3m`, `.msa`. |
 | `format`             | `string`              | No           | `"fasta"`   | The format of the MSA data. Supported formats: `"fasta"`                                                                                                   |
 | `num_significant`    | `int` \| None         | No           | `None`      | The number of significant sequences to include in the MSA.                                                                                                 |


### PR DESCRIPTION
Markdown tables should look like this

https://www.markdownlang.com/extended/tables.html
```
| Name  | Age | Occupation |
|-------|-----|------------| <--- line all the way to the ends
| Zhang | 25  | Engineer   |
| Li    | 30  | Designer   |
| Wang  | 28  | Product    |
```
Or my IDE complains 😅

