### PR TITLE
fix: add noqa and adjust types to quiet warnings

### DIFF
--- a/src/proteingym/base/assay.py
+++ b/src/proteingym/base/assay.py
@@ -147,7 +147,7 @@ class Assay:
     name: str
     """The name of the assay."""
 
-    records: list[tuple[Sequence | str | int | float | bool | str]]
+    records: list[tuple[Sequence | str | int | float | bool | str, ...]]
     """The records of the assay, tuple with Sequence, target values."""
 
     columns: list[str] = dataclasses.field(default_factory=lambda: ["sequence"])

--- a/tests/test_assay.py
+++ b/tests/test_assay.py
@@ -1,9 +1,11 @@
 from pathlib import Path
+from string import ascii_uppercase
 from zipfile import ZipFile
 
 import polars as pl
 import polars.testing
 import pytest
+from Bio.Seq import Seq
 from pydantic import ValidationError
 from semver import Version
 
@@ -17,7 +19,7 @@ from proteingym.base.assay import (
 )
 from proteingym.base.dataset import DatasetArchiveLayout
 from proteingym.base.manifest import Manifest
-from proteingym.base.sequence import Sequence, SequenceAlphabet
+from proteingym.base.sequence import Sequence, SequenceAlphabet, SequenceType
 
 
 @pytest.fixture
@@ -62,7 +64,7 @@ def test_assay_manifest_section(assay_file: Path) -> None:
             name="test_assay",
             description="Test assay",
             sequence="sequence",
-            sequence_alphabet="AA",
+            sequence_alphabet=SequenceAlphabet.AA,
             targets={"DMS Score": "target", "DMS Score2": "target2"},
             variables={"test_cond1": "true", "test_cond2": 42},
             path=assay_file,
@@ -100,7 +102,7 @@ def test_assay_manifest_section_validate_feature_names(assay_file: Path) -> None
             name="test_assay",
             description="Test assay",
             sequence="invalid_feature",
-            sequence_alphabet="AA",
+            sequence_alphabet=SequenceAlphabet.AA,  # noqa
             targets={"DMS Score": "invalid_feature"},
             variables={"test_cond1": "true", "test_cond2": 42},
             path=assay_file,
@@ -113,8 +115,8 @@ def test_assay() -> None:
         (
             Sequence(
                 name="seq1",
-                value="APC",
-                type="standard_sequence",
+                value=Seq("APC"),
+                type=SequenceType.STANDARD,
                 alphabet=SequenceAlphabet.DNA,
             ),
             1.56,
@@ -122,8 +124,8 @@ def test_assay() -> None:
         (
             Sequence(
                 name="seq2",
-                value="DEF",
-                type="standard_sequence",
+                value=Seq("DEF"),
+                type=SequenceType.STANDARD,
                 alphabet=SequenceAlphabet.DNA,
             ),
             2.0,
@@ -180,8 +182,8 @@ def test_as_manifest_section(tmp_path: Path) -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
-                    type="standard_sequence",
+                    value=Seq("APC"),
+                    type=SequenceType.STANDARD,
                     alphabet=SequenceAlphabet.DNA,
                 ),
                 1.56,
@@ -189,8 +191,8 @@ def test_as_manifest_section(tmp_path: Path) -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="DEF",
-                    type="standard_sequence",
+                    value=Seq("DEF"),
+                    type=SequenceType.STANDARD,
                     alphabet=SequenceAlphabet.DNA,
                 ),
                 2.0,
@@ -208,8 +210,18 @@ def test_as_manifest_section(tmp_path: Path) -> None:
 
 def test_assay_to_df() -> None:
     """Test converting an Assay to a Polars DataFrame."""
-    seq1 = Sequence(name="seq1", value="APC", type="standard_sequence", alphabet="DNA")
-    seq2 = Sequence(name="seq2", value="DEF", type="standard_sequence", alphabet="DNA")
+    seq1 = Sequence(
+        name="seq1",
+        value=Seq("APC"),
+        type=SequenceType.STANDARD,
+        alphabet=SequenceAlphabet.DNA,
+    )
+    seq2 = Sequence(
+        name="seq2",
+        value=Seq("DEF"),
+        type=SequenceType.STANDARD,
+        alphabet=SequenceAlphabet.DNA,
+    )
     assay = Assay(
         name="assay",
         records=[
@@ -237,8 +249,18 @@ def test_assay_to_df() -> None:
 
 def test_assay_to_df_single_string_target():
     """Test Assay.to_df with target_names as a single string."""
-    seq1 = Sequence(name="seq1", value="APC", type="standard_sequence", alphabet="DNA")
-    seq2 = Sequence(name="seq2", value="DEF", type="standard_sequence", alphabet="DNA")
+    seq1 = Sequence(
+        name="seq1",
+        value=Seq("APC"),
+        type=SequenceType.STANDARD,
+        alphabet=SequenceAlphabet.DNA,
+    )
+    seq2 = Sequence(
+        name="seq2",
+        value=Seq("DEF"),
+        type=SequenceType.STANDARD,
+        alphabet=SequenceAlphabet.DNA,
+    )
     assay = Assay(
         name="assay",
         records=[
@@ -260,13 +282,19 @@ def test_assay_to_df_invalid_target_name_returns_empty_df() -> None:
         records=[
             (
                 Sequence(
-                    name="seq1", value="APC", type="standard_sequence", alphabet="AA"
+                    name="seq1",
+                    value=Seq("APC"),
+                    type=SequenceType.STANDARD,
+                    alphabet=SequenceAlphabet.AA,
                 ),
                 1.56,
             ),
             (
                 Sequence(
-                    name="seq2", value="DEF", type="standard_sequence", alphabet="AA"
+                    name="seq2",
+                    value=Seq("DEF"),
+                    type=SequenceType.STANDARD,
+                    alphabet=SequenceAlphabet.AA,
                 ),
                 2.0,
             ),
@@ -314,13 +342,19 @@ def test_assay_dump(tmp_path: Path) -> None:
         records=[
             (
                 Sequence(
-                    name="seq1", value="APC", type="standard_sequence", alphabet="AA"
+                    name="seq1",
+                    value=Seq("APC"),
+                    type=SequenceType.STANDARD,
+                    alphabet=SequenceAlphabet.AA,
                 ),
                 1.56,
             ),
             (
                 Sequence(
-                    name="seq2", value="DEF", type="standard_sequence", alphabet="AA"
+                    name="seq2",
+                    value=Seq("DEF"),
+                    type=SequenceType.STANDARD,
+                    alphabet=SequenceAlphabet.AA,
                 ),
                 2.0,
             ),
@@ -341,8 +375,8 @@ def test_manifest_with_valid_assay_variables(assay_file: Path) -> None:
         manifest = Manifest(
             version=Version(1, 0),
             name="test_manifest",
-            assay_variables=[{"name": "pH"}, {"name": "temperature"}],
-            assays=[
+            assay_variables=[{"name": "pH"}, {"name": "temperature"}],  # noqa
+            assays=[  # noqa
                 {
                     "path": assay_file,
                     "sequence_alphabet": "DNA",
@@ -366,8 +400,8 @@ def test_manifest_with_undefined_assay_variable(assay_file: Path) -> None:
         Manifest(
             version=Version(1, 0),
             name="test_manifest",
-            assay_variables=[{"name": "pH"}],
-            assays=[
+            assay_variables=[{"name": "pH"}],  # noqa
+            assays=[  # noqa
                 {
                     "path": assay_file,
                     "sequence_alphabet": SequenceAlphabet.DNA,
@@ -387,7 +421,7 @@ def test_manifest_with_valid_assay_targets(assay_file: Path) -> None:
                 AssayTarget(name="DMS Score"),
                 AssayTarget(name="DMS Score2"),
             ],
-            assays=[
+            assays=[  # noqa
                 {
                     "path": assay_file,
                     "sequence_alphabet": SequenceAlphabet.DNA,
@@ -414,7 +448,7 @@ def test_manifest_with_undefined_assay_target(assay_file: Path) -> None:
             assay_targets=[
                 AssayTarget(name="DMS Bin"),
             ],
-            assays=[
+            assays=[  # noqa
                 {
                     "path": assay_file,
                     "sequence_alphabet": SequenceAlphabet.DNA,
@@ -437,17 +471,32 @@ def test_dataset_to_df_no_assays() -> None:
 
 @pytest.fixture
 def seq1() -> Sequence:
-    return Sequence(name="seq1", value="APC", type="standard_sequence", alphabet="DNA")
+    return Sequence(
+        name="seq1",
+        value=Seq("APC"),
+        type=SequenceType.STANDARD,
+        alphabet=SequenceAlphabet.DNA,
+    )
 
 
 @pytest.fixture
 def seq2() -> Sequence:
-    return Sequence(name="seq2", value="DEF", type="standard_sequence", alphabet="DNA")
+    return Sequence(
+        name="seq2",
+        value=Seq("DEF"),
+        type=SequenceType.STANDARD,
+        alphabet=SequenceAlphabet.DNA,
+    )
 
 
 @pytest.fixture
 def seq3() -> Sequence:
-    return Sequence(name="seq3", value="GHI", type="standard_sequence", alphabet="DNA")
+    return Sequence(
+        name="seq3",
+        value=Seq("GHI"),
+        type=SequenceType.STANDARD,
+        alphabet=SequenceAlphabet.DNA,
+    )
 
 
 @pytest.fixture
@@ -638,8 +687,18 @@ def test_dataset_to_df_assay_with_different_targets(
 
 def test_dataset_to_df_failed_assay_to_df() -> None:
     """Test that Dataset.to_df raises error if all Assay.to_df fail."""
-    seq1 = Sequence(name="seq1", value="APC", type="standard_sequence", alphabet="DNA")
-    seq2 = Sequence(name="seq2", value="DEF", type="standard_sequence", alphabet="DNA")
+    seq1 = Sequence(
+        name="seq1",
+        value=Seq("APC"),
+        type=SequenceType.STANDARD,
+        alphabet=SequenceAlphabet.DNA,
+    )
+    seq2 = Sequence(
+        name="seq2",
+        value=Seq("DEF"),
+        type=SequenceType.STANDARD,
+        alphabet=SequenceAlphabet.DNA,
+    )
     assay1 = Assay(
         name="assay1",
         records=[
@@ -668,8 +727,18 @@ def test_dataset_to_df_failed_assay_to_df() -> None:
 
 def test_dataset_to_df_drops_empty_target_rows() -> None:
     """Test that Dataset.to_df drops rows with all target values as None."""
-    seq1 = Sequence(name="seq1", value="APC", type="standard_sequence", alphabet="DNA")
-    seq2 = Sequence(name="seq2", value="DEF", type="standard_sequence", alphabet="DNA")
+    seq1 = Sequence(
+        name="seq1",
+        value=Seq("APC"),
+        type=SequenceType.STANDARD,
+        alphabet=SequenceAlphabet.DNA,
+    )
+    seq2 = Sequence(
+        name="seq2",
+        value=Seq("DEF"),
+        type=SequenceType.STANDARD,
+        alphabet=SequenceAlphabet.DNA,
+    )
     assay1 = Assay(
         name="assay1",
         records=[
@@ -680,7 +749,7 @@ def test_dataset_to_df_drops_empty_target_rows() -> None:
     )
     assay2 = Assay(
         name="assay2",
-        records=[
+        records=[  # noqa
             (seq1, None),
             (seq2, None),
         ],
@@ -692,9 +761,10 @@ def test_dataset_to_df_drops_empty_target_rows() -> None:
         assays=[assay1, assay2],
     )
     df = dataset.to_df(target_names=["DMS Score"])
-    assert df.shape == (1, 2), (
-        "DataFrame should drop rows with all target values as None"
-    )
+    assert df.shape == (
+        1,
+        2,
+    ), "DataFrame should drop rows with all target values as None"
     assert df["sequence"].to_list() == ["APC"]
     assert df["DMS Score"].to_list() == [1.0]
 
@@ -707,8 +777,8 @@ def test_dataset_with_dump_assays(tmp_path: Path) -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
-                    type="standard_sequence",
+                    value=Seq("APC"),
+                    type=SequenceType.STANDARD,
                     alphabet=SequenceAlphabet.DNA,
                 ),
                 1.0,
@@ -716,8 +786,8 @@ def test_dataset_with_dump_assays(tmp_path: Path) -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="DEF",
-                    type="standard_sequence",
+                    value=Seq("DEF"),
+                    type=SequenceType.STANDARD,
                     alphabet=SequenceAlphabet.DNA,
                 ),
                 2.0,
@@ -731,8 +801,8 @@ def test_dataset_with_dump_assays(tmp_path: Path) -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
-                    type="standard_sequence",
+                    value=Seq("APC"),
+                    type=SequenceType.STANDARD,
                     alphabet=SequenceAlphabet.DNA,
                 ),
                 1.0,
@@ -740,8 +810,8 @@ def test_dataset_with_dump_assays(tmp_path: Path) -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="DEF",
-                    type="standard_sequence",
+                    value=Seq("DEF"),
+                    type=SequenceType.STANDARD,
                     alphabet=SequenceAlphabet.DNA,
                 ),
                 3.0,
@@ -774,14 +844,20 @@ def test_dataset_instance_from_dump_assays(tmp_path: Path) -> None:
             # The sequence names are kept same as
             (
                 Sequence(
-                    name="APC", value="APC", type="standard_sequence", alphabet="AA"
+                    name="APC",
+                    value=Seq("APC"),
+                    type=SequenceType.STANDARD,
+                    alphabet=SequenceAlphabet.AA,
                 ),
                 1.56,
                 0.5,
             ),
             (
                 Sequence(
-                    name="DEF", value="DEF", type="standard_sequence", alphabet="AA"
+                    name="DEF",
+                    value=Seq("DEF"),
+                    type=SequenceType.STANDARD,
+                    alphabet=SequenceAlphabet.AA,
                 ),
                 2.0,
                 0.6,
@@ -816,8 +892,8 @@ def test_dataset_fails_with_duplicate_assay_names() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
-                    type="standard_sequence",
+                    value=Seq("APC"),
+                    type=SequenceType.STANDARD,
                     alphabet=SequenceAlphabet.DNA,
                 ),
                 1.0,
@@ -831,8 +907,8 @@ def test_dataset_fails_with_duplicate_assay_names() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
-                    type="standard_sequence",
+                    value=Seq("APC"),
+                    type=SequenceType.STANDARD,
                     alphabet=SequenceAlphabet.DNA,
                 ),
                 2.0,
@@ -846,8 +922,8 @@ def test_dataset_fails_with_duplicate_assay_names() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
-                    type="standard_sequence",
+                    value=Seq("APC"),
+                    type=SequenceType.STANDARD,
                     alphabet=SequenceAlphabet.DNA,
                 ),
                 3.0,
@@ -861,8 +937,8 @@ def test_dataset_fails_with_duplicate_assay_names() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
-                    type="standard_sequence",
+                    value=Seq("APC"),
+                    type=SequenceType.STANDARD,
                     alphabet=SequenceAlphabet.DNA,
                 ),
                 4.0,
@@ -919,7 +995,10 @@ def test_assay_repr() -> None:
         records=[
             (
                 Sequence(
-                    name="seq1", value="APC", type="standard_sequence", alphabet="AA"
+                    name="seq1",
+                    value=Seq("APC"),
+                    type=SequenceType.STANDARD,
+                    alphabet=SequenceAlphabet.AA,
                 ),
                 1.0,
             ),
@@ -937,7 +1016,10 @@ def test_assay_repr() -> None:
         records=[
             (
                 Sequence(
-                    name="seq1", value="APC", type="standard_sequence", alphabet="AA"
+                    name="seq1",
+                    value=Seq("APC"),
+                    type=SequenceType.STANDARD,
+                    alphabet=SequenceAlphabet.AA,
                 ),
                 2.0,
             ),
@@ -954,7 +1036,10 @@ def test_assay_repr() -> None:
         records=[
             (
                 Sequence(
-                    name="seq1", value="APC", type="standard_sequence", alphabet="AA"
+                    name="seq1",
+                    value=Seq("APC"),
+                    type=SequenceType.STANDARD,
+                    alphabet=SequenceAlphabet.AA,
                 ),
                 3.0,
             ),
@@ -970,7 +1055,10 @@ def test_assay_repr() -> None:
         records=[
             (
                 Sequence(
-                    name="seq1", value="APC", type="standard_sequence", alphabet="AA"
+                    name="seq1",
+                    value=Seq("APC"),
+                    type=SequenceType.STANDARD,
+                    alphabet=SequenceAlphabet.AA,
                 ),
                 4.0,
             ),
@@ -986,7 +1074,10 @@ def test_assay_repr() -> None:
     records = [
         (
             Sequence(
-                name=f"seq{i}", value=f"SEQ{i}", type="standard_sequence", alphabet="AA"
+                name=f"seq{i}",
+                value=Seq(ascii_uppercase[i]),
+                type=SequenceType.STANDARD,
+                alphabet=SequenceAlphabet.AA,
             ),
             i,
         )

--- a/tests/test_assay_operators.py
+++ b/tests/test_assay_operators.py
@@ -3,6 +3,7 @@ Module for testing assay operators.
 """
 
 import pytest
+from Bio.Seq import Seq
 
 from proteingym.base.assay import Assay, AssayTarget
 from proteingym.base.sequence import Sequence, SequenceAlphabet, SequenceType
@@ -19,7 +20,7 @@ def test_assay_length_equals_records_length() -> None:
     """The assay length should equal the number of records."""
     sequence = Sequence(
         name="seq1",
-        value="ACD",
+        value=Seq("ACD"),
         type=SequenceType.WILD_TYPE,
         alphabet=SequenceAlphabet.AA,
     )
@@ -59,7 +60,7 @@ def test_assay_with_record_equals_itself() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -75,7 +76,7 @@ def test_assay_with_record_contains_itself() -> None:
     """An assay with a record should contain itself."""
     sequence = Sequence(
         name="seq1",
-        value="APC",
+        value=Seq("APC"),
         type=SequenceType.WILD_TYPE,
         alphabet=SequenceAlphabet.AA,
     )
@@ -94,7 +95,7 @@ def test_assay_empty_in_assay_with_record() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -114,7 +115,7 @@ def test_assay_contains_subset() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -123,7 +124,7 @@ def test_assay_contains_subset() -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -138,7 +139,7 @@ def test_assay_contains_subset() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -158,7 +159,7 @@ def test_assay_contains_subset_mismatch() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -167,7 +168,7 @@ def test_assay_contains_subset_mismatch() -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -182,7 +183,7 @@ def test_assay_contains_subset_mismatch() -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -202,7 +203,7 @@ def test_assay_equals_with_name_mismatch() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -211,7 +212,7 @@ def test_assay_equals_with_name_mismatch() -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -227,7 +228,7 @@ def test_assay_equals_with_name_mismatch() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -236,7 +237,7 @@ def test_assay_equals_with_name_mismatch() -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -257,7 +258,7 @@ def test_assay_equals_with_variable() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -266,7 +267,7 @@ def test_assay_equals_with_variable() -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -287,7 +288,7 @@ def test_assay_equals_with_variable_mismatch() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -296,7 +297,7 @@ def test_assay_equals_with_variable_mismatch() -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -312,7 +313,7 @@ def test_assay_equals_with_variable_mismatch() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -321,7 +322,7 @@ def test_assay_equals_with_variable_mismatch() -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -342,7 +343,7 @@ def test_assay_contains_includes_variables() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -351,7 +352,7 @@ def test_assay_contains_includes_variables() -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -367,7 +368,7 @@ def test_assay_contains_includes_variables() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -376,7 +377,7 @@ def test_assay_contains_includes_variables() -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -397,7 +398,7 @@ def test_assay_contains_includes_variable_mismatch() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -406,7 +407,7 @@ def test_assay_contains_includes_variable_mismatch() -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -422,7 +423,7 @@ def test_assay_contains_includes_variable_mismatch() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -431,7 +432,7 @@ def test_assay_contains_includes_variable_mismatch() -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -452,7 +453,7 @@ def test_assay_contains_includes_variable_value_mismatch() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -461,7 +462,7 @@ def test_assay_contains_includes_variable_value_mismatch() -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -477,7 +478,7 @@ def test_assay_contains_includes_variable_value_mismatch() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -486,7 +487,7 @@ def test_assay_contains_includes_variable_value_mismatch() -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -508,7 +509,7 @@ def test_assay_slice_all(slc: slice | list[bool]) -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -517,7 +518,7 @@ def test_assay_slice_all(slc: slice | list[bool]) -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -539,7 +540,7 @@ def test_assay_slice_first_with_slice(slc: slice | list[bool]) -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -548,7 +549,7 @@ def test_assay_slice_first_with_slice(slc: slice | list[bool]) -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -563,7 +564,7 @@ def test_assay_slice_first_with_slice(slc: slice | list[bool]) -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -584,7 +585,7 @@ def test_assay_slice_last(slc: slice | list[bool]) -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -593,7 +594,7 @@ def test_assay_slice_last(slc: slice | list[bool]) -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -608,7 +609,7 @@ def test_assay_slice_last(slc: slice | list[bool]) -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -628,7 +629,7 @@ def test_assay_get_first_raises_not_implemented_error() -> None:
             (
                 Sequence(
                     name="seq1",
-                    value="APC",
+                    value=Seq("APC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -637,7 +638,7 @@ def test_assay_get_first_raises_not_implemented_error() -> None:
             (
                 Sequence(
                     name="seq2",
-                    value="GTC",
+                    value=Seq("GTC"),
                     type=SequenceType.WILD_TYPE,
                     alphabet=SequenceAlphabet.AA,
                 ),
@@ -649,4 +650,4 @@ def test_assay_get_first_raises_not_implemented_error() -> None:
     with pytest.raises(
         NotImplementedError, match="Getting a single record is not supported."
     ):
-        assay[0]
+        assay[0]  # noqa

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -5,6 +5,7 @@ from zipfile import ZipFile
 import pytest
 from Bio.Align import MultipleSeqAlignment
 from Bio.PDB.Structure import Structure as BioStructure
+from Bio.Seq import Seq
 from typer.testing import CliRunner
 
 from proteingym.base.__main__ import app
@@ -158,7 +159,7 @@ def test_list_datasets_invalid_format(runner: CliRunner, dataset_file: Path) -> 
 def test_list_datasets_json_serialization() -> None:
     sequence = Sequence(
         name="test",
-        value="test",
+        value=Seq("test"),
         type=SequenceType.WILD_TYPE,
         alphabet=SequenceAlphabet.AA,
     )

--- a/tests/test_dataset_subsets.py
+++ b/tests/test_dataset_subsets.py
@@ -93,5 +93,5 @@ def test_subsets_dump_creates_valid_archive(
 ) -> None:
     """Dumping a subsets creates a valid archive."""
     archive_path = subsets_fifty_fifty.dump(path=tmp_path)
-    with ZipFile(archive_path, "r") as zip:
-        assert zip.testzip() is None  # No corrupt files
+    with ZipFile(archive_path, "r") as zip_:
+        assert zip_.testzip() is None  # No corrupt files

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -191,9 +191,9 @@ def test_manifest_from_path_has_protein_data(
 
 
 def test_manifest_version() -> None:
-    """The manifest version should support comparisions."""
-    manifest_v1 = Manifest(name="test", version="1.0.0")
-    manifest_v2 = Manifest(name="test", version="2.0.0")
+    """The manifest version should support comparisons."""
+    manifest_v1 = Manifest(name="test", version="1.0.0")  # noqa
+    manifest_v2 = Manifest(name="test", version="2.0.0")  # noqa
 
     assert manifest_v1.version == manifest_v1.version
     assert manifest_v1.version <= manifest_v1.version
@@ -208,7 +208,7 @@ def test_manifest_version() -> None:
 
 def test_manifest_dump_creates_file_with_content(tmp_path: Path) -> None:
     """The manifest dump should create a file with content."""
-    manifest = Manifest(version="1.0.0", name="test")
+    manifest = Manifest(version="1.0.0", name="test")  # noqa
 
     path = manifest.dump(path=tmp_path)
 
@@ -218,7 +218,7 @@ def test_manifest_dump_creates_file_with_content(tmp_path: Path) -> None:
 
 def test_manifest_dump_from_path_unit(tmp_path: Path) -> None:
     """The manifest dump creates a file that can be loaded back with same content."""
-    manifest = Manifest(version="1.0.0", name="test")
+    manifest = Manifest(version="1.0.0", name="test")  # noqa
 
     path = manifest.dump(path=tmp_path)
 
@@ -258,7 +258,7 @@ def test_manifest_dump_from_path_unit_docs_example(
 
 def test_manifest_dump_version_string(tmp_path: Path) -> None:
     """The version should be dumped as a string."""
-    manifest = Manifest(name="test", version="1.0.0")
+    manifest = Manifest(name="test", version="1.0.0")  # noqa
 
     path = manifest.dump(path=tmp_path)
 

--- a/tests/test_msa.py
+++ b/tests/test_msa.py
@@ -13,7 +13,7 @@ from pydantic import ValidationError
 
 from proteingym.base import Dataset
 from proteingym.base.msa import MSA, MSAFormat, MSAManifestSection
-from proteingym.base.sequence import Sequence
+from proteingym.base.sequence import Sequence, SequenceAlphabet, SequenceType
 
 
 def test_msa_manifest_section_minimal(tmp_path: Path) -> None:
@@ -80,7 +80,7 @@ def test_msa_manifest_section_missing_path() -> None:
         "validation error for MSAManifestSection\npath\n  Path does not point to a file"
     )
     with pytest.raises(ValidationError, match=match):
-        MSAManifestSection(path="non_existent.msa")
+        MSAManifestSection(path="non_existent.msa")  # noqa
 
 
 @pytest.mark.parametrize("field", ["name", "description"])
@@ -148,8 +148,6 @@ def test_msa_minimal() -> None:
 @pytest.fixture
 def multiple_sequence_alignment() -> MultipleSeqAlignment:
     """Minimal biopython multiple sequence alignment for testing."""
-    alignment = MultipleSeqAlignment([])
-
     a = SeqRecord(Seq("AAAACGT"), id="Alpha")
     b = SeqRecord(Seq("AAA-CGT"), id="Beta")
     c = SeqRecord(Seq("AAAAGGT"), id="Gamma")
@@ -189,7 +187,7 @@ def a3m_file(tmp_path: Path, multiple_sequence_alignment: MultipleSeqAlignment) 
 
 def test_msa_from_manifest_section_with_a3m(a3m_file: Path) -> None:
     """A MSA can be created from a manifest section with A3M file."""
-    section = MSAManifestSection(path=a3m_file, format="fasta")
+    section = MSAManifestSection(path=a3m_file, format="fasta")  # noqa
 
     msa = MSA.from_manifest_section(section)
 
@@ -295,7 +293,10 @@ def test_msa_reference_sequence_present_in_dataset(
 ) -> None:
     """A ValueError is raised if the reference sequence is not in the MSA."""
     seq = Sequence(
-        name="ref_seq", value=Seq("TTTTTTT"), type="wild_type", alphabet="DNA"
+        name="ref_seq",
+        value=Seq("TTTTTTT"),
+        type=SequenceType.WILD_TYPE,
+        alphabet=SequenceAlphabet.DNA,
     )
     msa = MSA(
         name="test", value=multiple_sequence_alignment, reference_sequence="ref_seq"
@@ -344,11 +345,11 @@ def test_dataset_dump_with_msa(
 
     path = dataset.dump(path=tmp_path)
 
-    zip = ZipFile(path)
-    assert not zip.testzip(), "Dataset dump contains a bad file."
-    assert "msas/msa.fasta" in zip.namelist(), "MSA file not found in dataset dump."
+    zip_ = ZipFile(path)
+    assert not zip_.testzip(), "Dataset dump contains a bad file."
+    assert "msas/msa.fasta" in zip_.namelist(), "MSA file not found in dataset dump."
 
-    with zip.open("msas/msa.fasta", "r") as msa_file:
+    with zip_.open("msas/msa.fasta", "r") as msa_file:
         string_io = io.StringIO(msa_file.read().decode("utf-8"))
         loaded_msa = AlignIO.read(string_io, "fasta")
         assert multiple_sequence_alignment.alignment == loaded_msa.alignment

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -26,7 +26,7 @@ def test_sequence_manifest_section_minimal(tmp_path: Path) -> None:
     path.touch()
 
     try:
-        SequenceManifestSection(type="wild_type", alphabet="DNA", path=path)
+        SequenceManifestSection(type="wild_type", alphabet="DNA", path=path)  # noqa
     except ValidationError as e:
         raise AssertionError("Could not create SequenceManifestSection") from e
     else:
@@ -62,8 +62,8 @@ def test_sequence_manifest_section_missing_path() -> None:
     )
     with pytest.raises(ValidationError, match=match):
         SequenceManifestSection(
-            type="wild_type",
-            alphabet="DNA",
+            type="wild_type",  # noqa
+            alphabet="DNA",  # noqa
             path=Path("non_existent.fasta"),
         )
 
@@ -73,7 +73,7 @@ def test_sequence_manifest_section_serialize_path_as_posix(tmp_path: Path) -> No
     path = tmp_path / "sequence.fasta"
     path.touch()
 
-    section = SequenceManifestSection(type="wild_type", alphabet="DNA", path=path)
+    section = SequenceManifestSection(type="wild_type", alphabet="DNA", path=path)  # noqa
 
     assert section.model_dump().get("path") == path.as_posix()
 
@@ -81,12 +81,12 @@ def test_sequence_manifest_section_serialize_path_as_posix(tmp_path: Path) -> No
 def test_sequence_manifest_section_serialize_path_as_posix_relative_to(
     tmp_path: Path,
 ) -> None:
-    """The path is serialized as a Posix path relatie to another path."""
+    """The path is serialized as a Posix path relative to another path."""
     path = tmp_path / "sequence.fasta"
     path.touch()
     context = {"relative_to_path": tmp_path}
 
-    section = SequenceManifestSection(type="wild_type", alphabet="DNA", path=path)
+    section = SequenceManifestSection(type="wild_type", alphabet="DNA", path=path)  # noqa
 
     assert section.model_dump(context=context).get("path") == "sequence.fasta"
 
@@ -107,8 +107,8 @@ def test_sequence_manifest_section_serialize_strenum_as_string(tmp_path: Path) -
     )
 
     section_in_toml = toml.dumps(section.model_dump())
-    assert SequenceType.WILD_TYPE.value in section_in_toml
-    assert SequenceAlphabet.DNA.value in section_in_toml
+    assert str(SequenceType.WILD_TYPE.value) in section_in_toml
+    assert str(SequenceAlphabet.DNA.value) in section_in_toml
 
 
 def test_sequence_manifest_section_raises_validation_error_for_unsupported_format(
@@ -123,11 +123,11 @@ def test_sequence_manifest_section_raises_validation_error_for_unsupported_forma
         "Unsupported sequence format: unsupported"
     )
     with pytest.raises(ValidationError, match=match):
-        SequenceManifestSection(type="wild_type", alphabet="DNA", path=path)
+        SequenceManifestSection(type="wild_type", alphabet="DNA", path=path)  # noqa
 
 
 @pytest.mark.parametrize(
-    "name, value, description, type, alphabet",
+    "name, value, description, type_, alphabet",
     [
         ("seq1", Seq("ATCG"), "Test sequence 1", SequenceType("wild_type"), "DNA"),
         ("seq2", Seq("AUGC"), "Test sequence 2", "starting_sequence", "RNA"),
@@ -140,12 +140,12 @@ def test_sequence_manifest_section_raises_validation_error_for_unsupported_forma
         ),
     ],
 )
-def test_sequence(name, value, description, type, alphabet):
+def test_sequence(name, value, description, type_, alphabet):
     sequence = Sequence(
         name=name,
         value=value,
         description=description,
-        type=SequenceType(type),
+        type=SequenceType(type_),
         alphabet=SequenceAlphabet(alphabet),
     )
     assert isinstance(sequence.value, Seq)
@@ -158,8 +158,8 @@ def test_sequence_from_manifest_section_multiple_seqs_in_file(tmp_path: Path) ->
     fasta_file.write_text(">seq1\nATCG\n>seq2\nAUGC\n")
 
     section = SequenceManifestSection(
-        type="wild_type",
-        alphabet="DNA",
+        type="wild_type",  # noqa
+        alphabet="DNA",  # noqa
         path=fasta_file,
     )
 
@@ -208,13 +208,13 @@ def test_dataset_dump_with_sequence(tmp_path: Path) -> None:
 
     path = dataset.dump(path=tmp_path)
 
-    zip = ZipFile(path)
-    assert not zip.testzip(), "Dataset dump contains a bad file."
-    assert "sequences/seq.fasta" in zip.namelist(), (
+    zip_ = ZipFile(path)
+    assert not zip_.testzip(), "Dataset dump contains a bad file."
+    assert "sequences/seq.fasta" in zip_.namelist(), (
         "Sequence file not found in dataset dump."
     )
 
-    with zip.open("sequences/seq.fasta", "r") as sequence_file:
+    with zip_.open("sequences/seq.fasta", "r") as sequence_file:
         string_io = io.StringIO(sequence_file.read().decode("utf-8"))
         loaded_sequence = SeqIO.read(string_io, "fasta")
         assert bio_sequence == loaded_sequence.seq
@@ -322,7 +322,7 @@ def test_dataset_loads_multiple_sequences_from_file(tmp_path: Path) -> None:
     dataset_manifest = Manifest(
         version=MANIFEST_LATEST_VERSION,
         name="test",
-        sequences=[
+        sequences=[  # noqa
             {
                 "path": fasta_file,
                 "type": "wild_type",


### PR DESCRIPTION
# Changes

Lots of little type adjustments and additio of #noqa - where type is intentionally not matching annotations (like passing dict to a `BaseModel`)
# Checklist

- [x] I broke the PR down so that it contains a reasonable amount of changes for an effective review
- [x] I performed a self-review of my code. Amongst other things, I have commented my code in hard-to-understand areas.
- [x] I made corresponding changes to the documentation
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I accounted for dependent changes to be merged and published in downstream modules
