### PR TITLE
fix: dont shadow builtins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,4 +63,5 @@ select = [
     "I", # isort
     # "C", # flake8-comprehensions
     "B", # flake8-bugbear
+    "A", # flake8-builtins
 ]

--- a/src/proteingym/base/__main__.py
+++ b/src/proteingym/base/__main__.py
@@ -255,7 +255,7 @@ def generate_data(
     sequence_length: Annotated[
         int, typer.Option(help="Length of sequence for the sequence column")
     ] = 100,
-    format: Annotated[
+    fmt: Annotated[
         str,
         typer.Option(
             help="Output format",
@@ -274,7 +274,7 @@ def generate_data(
         feature2: Name of the second dummy feature. Defaults to "bar".
         n_rows: Number of rows to generate in the data frame. Defaults to 500.
         sequence_length: Length of sequence for the sequence column. Defaults to 100.
-        format: Output format. Currently only supports "csv". Defaults to "csv".
+        fmt: Output format. Currently only supports "csv". Defaults to "csv".
 
     Outputs:
         Prints the generated CSV data to stdout.
@@ -287,7 +287,7 @@ def generate_data(
         feature_names=[feature1, feature2],
     )
 
-    if format.lower() == "csv":
+    if fmt.lower() == "csv":
         typer.echo(output.write_csv(), nl=False)
 
 

--- a/src/proteingym/base/assay.py
+++ b/src/proteingym/base/assay.py
@@ -471,7 +471,7 @@ class Assay:
         return df
 
     def dump(
-        self, *, path: Path | None = None, format: AssayFormat = AssayFormat.CSV
+        self, *, path: Path | None = None, fmt: AssayFormat = AssayFormat.CSV
     ) -> Path:
         """Dump the assay data to a file.
 
@@ -481,7 +481,7 @@ class Assay:
         Args:
             path (Path): The output directory to dump the assay file in. If
                 None, the current working directory is used.
-            format (AssayFormat): The file format
+            fmt (AssayFormat): The file format
 
         Raises:
             NotImplementedError if the file type is not supported.
@@ -489,7 +489,7 @@ class Assay:
 
         path = path or Path.cwd()
         if path.is_dir():
-            path = path / f"{self.name}{format.value}"
+            path = path / f"{self.name}{fmt.value}"
 
         df = pl.DataFrame(
             self.records,
@@ -501,9 +501,9 @@ class Assay:
                 lambda seq: str(seq.value), return_dtype=pl.Utf8
             )
         )
-        match format:
+        match fmt:
             case AssayFormat.CSV:
                 df.write_csv(path)
             case _:
-                raise NotImplementedError(f"Unsupported file type: {format.value}")
+                raise NotImplementedError(f"Unsupported file type: {fmt.value}")
         return path

--- a/src/proteingym/base/dataset.py
+++ b/src/proteingym/base/dataset.py
@@ -485,7 +485,7 @@ class Dataset(BaseModel):
 
     def _write_paths_to_zip(
         self,
-        zip: ZipFile,
+        zip_: ZipFile,
         *paths: Path,
         arcname: Path | None = None,
         arcname_prefix: Path = Path(),
@@ -496,7 +496,7 @@ class Dataset(BaseModel):
             "because it creates a name collision"
         )
         for path in paths:
-            zip.write(path, arcname=arcname_prefix / (arcname or path.name))
+            zip_.write(path, arcname=arcname_prefix / (arcname or path.name))
 
     def _create_archive(self, path: Path, *, temporary_directory: Path) -> Path:
         """Create a ZIP archive of the dataset."""
@@ -506,27 +506,27 @@ class Dataset(BaseModel):
         data_paths = self._dump_data(temporary_directory)
         manifest = self._create_manifest(data_paths)
         manifest_path = manifest.dump(path=temporary_directory)
-        with ZipFile(archive_path, "w") as zip:
+        with ZipFile(archive_path, "w") as zip_:
             self._write_paths_to_zip(
-                zip, manifest_path, arcname=DatasetArchiveLayout.MANIFEST_FILE
+                zip_, manifest_path, arcname=DatasetArchiveLayout.MANIFEST_FILE
             )
             self._write_paths_to_zip(
-                zip,
+                zip_,
                 *[assay.path for assay in manifest.assays],
                 arcname_prefix=DatasetArchiveLayout.ASSAYS_DIRECTORY,
             )
             self._write_paths_to_zip(
-                zip,
+                zip_,
                 *[sequence.path for sequence in manifest.sequences],
                 arcname_prefix=DatasetArchiveLayout.SEQUENCES_DIRECTORY,
             )
             self._write_paths_to_zip(
-                zip,
+                zip_,
                 *[structure.path for structure in manifest.structures],
                 arcname_prefix=DatasetArchiveLayout.STRUCTURES_DIRECTORY,
             )
             self._write_paths_to_zip(
-                zip,
+                zip_,
                 *[msa.path for msa in manifest.msas],
                 arcname_prefix=DatasetArchiveLayout.MSAS_DIRECTORY,
             )
@@ -837,12 +837,12 @@ class Subsets:
         # While a SE practice is to avoid IO to disk where possible,
         # we use a temporary directory here as long as dataset dump requires
         # it.
-        with ZipFile(path, "r") as zip, TemporaryDirectory() as temp_dir:
-            dataset_archive = zip.extract(
+        with ZipFile(path, "r") as zip_, TemporaryDirectory() as temp_dir:
+            dataset_archive = zip_.extract(
                 SubsetsArchiveLayout.DATASET_ARCHIVE, path=temp_dir
             )
             dataset = Dataset.from_path(dataset_archive)
-            slices_str = zip.read(SubsetsArchiveLayout.SLICES_FILE)
+            slices_str = zip_.read(SubsetsArchiveLayout.SLICES_FILE)
             slices = cls._loads_slices(slices_str)
         return cls(dataset=dataset, slices=slices)
 
@@ -880,9 +880,9 @@ class Subsets:
         # While a SE practice is to avoid IO to disk where possible,
         # we use a temporary directory here as long as dataset dump requires
         # it.
-        with ZipFile(path, "w") as zip, TemporaryDirectory() as temp_dir:
+        with ZipFile(path, "w") as zip_, TemporaryDirectory() as temp_dir:
             dataset_archive = self.dataset.dump(path=Path(temp_dir))
-            zip.write(dataset_archive, arcname=SubsetsArchiveLayout.DATASET_ARCHIVE)
+            zip_.write(dataset_archive, arcname=SubsetsArchiveLayout.DATASET_ARCHIVE)
             slices_str = self._dumps_slices()
-            zip.writestr(SubsetsArchiveLayout.SLICES_FILE, slices_str)
+            zip_.writestr(SubsetsArchiveLayout.SLICES_FILE, slices_str)
         return path

--- a/src/proteingym/base/msa.py
+++ b/src/proteingym/base/msa.py
@@ -147,9 +147,9 @@ class MSAManifestSection(MSAMetadataManifestSection):
         return path.as_posix()
 
     @field_serializer("format", check_fields=True)
-    def _serialize_str_enum(self, format: MSAFormat) -> str:
+    def _serialize_str_enum(self, fmt: MSAFormat) -> str:
         """Serialize a StrEnum as a string."""
-        return format.value
+        return fmt.value
 
 
 @dataclasses.dataclass
@@ -272,7 +272,7 @@ class MSA:
         )
 
     def dump(
-        self, *, path: Path | None = None, format: MSAFormat = MSAFormat.FASTA
+        self, *, path: Path | None = None, fmt: MSAFormat = MSAFormat.FASTA
     ) -> Path:
         """Dump the multiple sequence alignment to a file.
 
@@ -282,7 +282,7 @@ class MSA:
         Args:
             path (Path | None): The directory path to save the MSA file in.
                 Defaults to the current working directory.
-            format (MSAFormat): The format to save the MSA in. Defaults to
+            fmt (MSAFormat): The format to save the MSA in. Defaults to
                 MSAFormat.FASTA.
 
         Raises:
@@ -296,10 +296,10 @@ class MSA:
             sequence alignment. This metadata should be stored with dumping the
             dataset.
         """
-        if format not in MSAFormat:
-            raise ValueError(f"Format {format} is not supported for MSA dumping.")
+        if fmt not in MSAFormat:
+            raise ValueError(f"Format {fmt} is not supported for MSA dumping.")
         path = path or Path.cwd()
         if path.is_dir():
-            path /= f"{self.name}.{format.value}"
-        AlignIO.write(self.value, path, format=format.value)
+            path /= f"{self.name}.{fmt.value}"
+        AlignIO.write(self.value, path, format=fmt.value)
         return path

--- a/src/proteingym/base/sequence.py
+++ b/src/proteingym/base/sequence.py
@@ -91,9 +91,9 @@ class SequenceManifestSection(BaseModel):
         """Optionally, extend the path with the `relative_to_path` from the context."""
         if info.context and info.context.get("relative_to_path"):
             path = info.context["relative_to_path"] / path
-        format = path.suffix[1:].lower()
-        if format not in SequenceFormat:
-            raise ValueError(f"Unsupported sequence format: {format}")
+        fmt = path.suffix[1:].lower()
+        if fmt not in SequenceFormat:
+            raise ValueError(f"Unsupported sequence format: {fmt}")
         return path
 
     @field_serializer("path", check_fields=True)
@@ -197,7 +197,7 @@ class Sequence:
         )
 
     def dump(
-        self, *, path: Path | None = None, format: SequenceFormat = SequenceFormat.FASTA
+        self, *, path: Path | None = None, fmt: SequenceFormat = SequenceFormat.FASTA
     ) -> Path:
         """Dump the sequence to a file in `path` directory.
 
@@ -209,18 +209,18 @@ class Sequence:
         Args:
             path (Path): The output directory path to dump the sequence to. If
                 None, the current working directory is used.
-            format (SequenceFormat): The format to dump the sequence in.
+            fmt (SequenceFormat): The format to dump the sequence in.
 
         Raises:
             ValueError: If the path does not have a valid sequence file extension.
         """
-        if format not in SequenceFormat:
-            raise ValueError(f"Unsupported sequence format: {format}")
+        if fmt not in SequenceFormat:
+            raise ValueError(f"Unsupported sequence format: {fmt}")
         path = path or Path.cwd()
         if path.is_dir():
-            path = path / f"{self.name}.{format.value}"
+            path = path / f"{self.name}.{fmt.value}"
         record = SeqRecord(
             seq=self.value, id=self.name, name=self.name, description=self.description
         )
-        SeqIO.write(record, path, format.value)
+        SeqIO.write(record, path, fmt.value)
         return path

--- a/src/proteingym/base/structure.py
+++ b/src/proteingym/base/structure.py
@@ -168,7 +168,7 @@ class Structure:
         )
 
     def dump(
-        self, *, path: Path | None = None, format: StructureFormat = StructureFormat.PDB
+        self, *, path: Path | None = None, fmt: StructureFormat = StructureFormat.PDB
     ) -> Path:
         """Dump the structure to a file.
 
@@ -181,20 +181,20 @@ class Structure:
         Args:
             path (Path): The output directory path to dump the structure to. If
                 None, the current working directory is used.
-            format (StructureFormat): The format to dump the structure in.
+            fmt (StructureFormat): The format to dump the structure in.
 
         Raises:
             NotImplementedError if the file type is not supported.
         """
         path = path or Path.cwd()
-        structure_path = path / f"{self.name}{format.value}"
-        match format:
+        structure_path = path / f"{self.name}{fmt.value}"
+        match fmt:
             case StructureFormat.PDB:
                 io = PDBIO()
             case StructureFormat.MMCIF:
                 io = MMCIFIO()
             case _:
-                raise NotImplementedError(f"Unsupported file type: {format.value}")
+                raise NotImplementedError(f"Unsupported file type: {fmt.value}")
         io.set_structure(self.value)
         with structure_path.open("w", encoding="utf-8") as file:
             io.save(file)

--- a/tests/test_assay.py
+++ b/tests/test_assay.py
@@ -238,7 +238,7 @@ def test_as_manifest_section(tmp_path: Path) -> None:
         ],
         columns=["sequence", "DMS Score"],
     )
-    path = assay.dump(path=tmp_path, format=AssayFormat.CSV)
+    path = assay.dump(path=tmp_path, fmt=AssayFormat.CSV)
     manifest = assay.as_manifest_section(path=path)
     assert "DMS Score" in manifest.path.read_text()
     assert "sequence" in manifest.path.read_text()
@@ -367,7 +367,7 @@ def test_as_manifest_section_with_no_records(tmp_path: Path) -> None:
         name="assay",
         records=[],
     )
-    path = assay.dump(path=tmp_path, format=AssayFormat.CSV)
+    path = assay.dump(path=tmp_path, fmt=AssayFormat.CSV)
     manifest = assay.as_manifest_section(path=path)
     assert manifest.name == "assay"
     assert manifest.sequence_alphabet is None
@@ -399,7 +399,7 @@ def test_assay_dump(tmp_path: Path) -> None:
         ],
         columns=["sequence", "DMS Score"],
     )
-    dumped_path = assay.dump(path=tmp_path, format=AssayFormat.CSV)
+    dumped_path = assay.dump(path=tmp_path, fmt=AssayFormat.CSV)
     assert dumped_path == tmp_path / "assay.csv"
     assert (tmp_path / "assay.csv").exists()
     content = dumped_path.read_text()

--- a/tests/test_dataset_subsets.py
+++ b/tests/test_dataset_subsets.py
@@ -148,8 +148,8 @@ def test_subsets_dump_from_path_is_unit_function_with_strategies(
     archive_path = subsets_with_data_distribution_scenarios.dump(path=tmp_path)
     subsets_recovered = Subsets.from_path(archive_path)
     assert subsets_with_data_distribution_scenarios == subsets_recovered
-    with ZipFile(archive_path, "r") as zip:
-        assert zip.testzip() is None  # No corrupt files
+    with ZipFile(archive_path, "r") as zip_:
+        assert zip_.testzip() is None  # No corrupt files
 
 
 def test_dataset_slice_with_columns_slices_assay_columns(

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -224,7 +224,7 @@ def test_structure_dump_to_cif(tmp_path: Path, bio_structure: BioStructure) -> N
     """A Structure can be dumped to a cif file."""
     structure = Structure(name="test", value=bio_structure)
 
-    path = structure.dump(path=tmp_path, format=StructureFormat.MMCIF)
+    path = structure.dump(path=tmp_path, fmt=StructureFormat.MMCIF)
 
     # There is an inconsistency in biopython that loads the full name of an Atom
     # differently for a PDB and CIF file - the full name is trimmed for the


### PR DESCRIPTION
Here's an opinionated one: enable https://docs.astral.sh/ruff/rules/#flake8-builtins-a

Best practice is to not use names for variables that shadow python builtins. Let's make it a policy.

What do you think? 

# Changes

- format -> fmt
- zip -> zip_

# Checklist

- [x] I broke the PR down so that it contains a reasonable amount of changes for an effective review
- [x] I performed a self-review of my code. Amongst other things, I have commented my code in hard-to-understand areas.
- [x] I made corresponding changes to the documentation
