### PR TITLE
Update authors to "Protein Gym team"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,9 @@
 name = "proteingym-base"
 description = "Infrastructure for protein variant effect prediction. Dataset class and tools to facilitate benchmarking."
 readme = "README.md"
-authors = [
-    { name = "Pascal Notin", email = "pascal.notin@gmail.com"},
-    { name = "Henning Redestig", email = "henning.redestig@iff.com"},
-    { name = "Karel van der Weg", email = "karel.weg@iff.com"},
-]
+authors = [  
+    { name = "ProteinGym team", email = "proteingym@googlegroups.com" }  
+]  
 dynamic = ["version"]  # Dynamically set hatch version using git tags
 classifiers = ["Private :: Do Not Upload"]  # Do not upload to public PYPI (by accident)
 requires-python = ">=3.12"


### PR DESCRIPTION
# Changes

Remove authors referring to persons (sorry!). We want a team in which we can rotate contributors for long-term project support.

The Github contributors contains this information: https://github.com/ProteinGym/proteingym-base/graphs/contributors. 

# Checklist

- [ ] I broke the PR down so that it contains a reasonable amount of changes for an effective review
- [x] I performed a self-review of my code. Amongst other things, I have commented my code in hard-to-understand areas.
- [ ] I made corresponding changes to the documentation
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I accounted for dependent changes to be merged and published in downstream modules
