### PR TITLE
fix: test generated aggregation warnings should not be visible

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,9 @@ packages = ["src/proteingym/"]
 [tool.pytest.ini_options]
 testpaths = ["tests", "README.md"]
 addopts = "--doctest-modules --doctest-glob='*.md' --cov=proteingym.base --cov-branch --cov-report xml --cov-fail-under=80"
-
+filterwarnings = [
+    'ignore:.*Aggregation applied.*:UserWarning',
+]
 [tool.ruff]
 line-length = 88
 


### PR DESCRIPTION
# Changes

New agg function makes pytest list warnings making it look like something is wrong. Filter them.
