### PR TITLE
Add job for releasing to PyPI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,12 @@ jobs:
           uv pip install dist/proteingym_base-*.whl
           uv run --with proteingym_base --no-project --no-cache -- python -c "import proteingym.base"
 
+      - name: Upload the Python package distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
   github-release:
     runs-on: ubuntu-latest
     needs: test-release


### PR DESCRIPTION
# Changes

Resolves #357

Add job to release to PyPI based on https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/.

@hredestig : We need to add this workflow as a trusted publisher to the PyPI account https://docs.pypi.org/trusted-publishers/adding-a-publisher/

# Checklist

- [ ] I broke the PR down so that it contains a reasonable amount of changes for an effective review
- [ ] I performed a self-review of my code. Amongst other things, I have commented my code in hard-to-understand areas.
- [ ] I made corresponding changes to the documentation
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I accounted for dependent changes to be merged and published in downstream modules
