### PR TITLE
fix: also run style format as ci check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,9 @@ jobs:
       - name: Ruff check
         run: uv run ruff check src tests
 
+      - name: Ruff format
+        run: uv run ruff format --check src tests
+
   test:
     name: test
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Ruff format and ruff check are not the same, run both

Without `ruff format --check` style things like single or double quotes are not linted