### PR TITLE
Fixes ruff format tests

### DIFF
--- a/tests/test_assay_operators.py
+++ b/tests/test_assay_operators.py
@@ -713,7 +713,7 @@ def test_assay_slice_column_string_raises_not_implemented_error(
     with pytest.raises(
         NotImplementedError, match="Getting a single column is not supported."
     ):
-        assay["stability"] # noqa
+        assay["stability"]  # noqa
 
 
 def test_assay_slice_column_string_raises_key_error_for_unknown_column(
@@ -727,7 +727,7 @@ def test_assay_slice_column_string_raises_key_error_for_unknown_column(
     )
 
     with pytest.raises(KeyError, match=r"Undefined columns: {'unknown'}"):
-        assay[["sequence", "unknown"]] # noqa
+        assay[["sequence", "unknown"]]  # noqa
 
 
 def test_assay_slice_column(seq1: Sequence, seq2: Sequence) -> None:

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -67,7 +67,7 @@ def test_structure_manifest_section_missing_path() -> None:
         "Path does not point to a file"
     )
     with pytest.raises(ValidationError, match=match):
-        StructureManifestSection(path="non_existent.pdb") # noqa
+        StructureManifestSection(path="non_existent.pdb")  # noqa
 
 
 @pytest.mark.parametrize("field", ["name", "description"])


### PR DESCRIPTION
# Changes

When we added ruff format to the pipelines we forgot to check if all files were ruff formatted.