### PR TITLE
added subsets to init imports

### DIFF
--- a/src/proteingym/base/__init__.py
+++ b/src/proteingym/base/__init__.py
@@ -11,10 +11,11 @@ Attributes :
         loading and validating dataset from metadata.
 """
 
-from .dataset import Dataset
+from .dataset import Dataset, Subsets
 from .manifest import Manifest
 
 __all__ = [
     "Dataset",
     "Manifest",
+    "Subsets",
 ]


### PR DESCRIPTION
# Changes
Small change to be able to import Subsets from proteingym.base instead of proteingym.base.splits.

Think this makes more sense as most likely we'll be working more with subsets than datasets.