### PR TITLE
removed type hints from docstrings -> google style docstrings.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,9 @@ plugins:
 - mkdocs-autoapi:
     autoapi_add_nav_entry: Code Reference
     autoapi_dir: src
+    autoapi_ignore:
+      - "**/__about__.py"
+      - "**/__main__.py"
 - mkdocstrings:
     handlers:
       python:

--- a/src/proteingym/base/assay.py
+++ b/src/proteingym/base/assay.py
@@ -284,7 +284,7 @@ class AssaySlice:
         """Create an assay slice from a JSON string.
 
         Args:
-            contents (str): The JSON string to create the assay slice from.
+            contents: The JSON string to create the assay slice from.
 
         Returns:
             The assay slice created from the JSON string.
@@ -334,7 +334,7 @@ class AssayRaw:
         """Creates AssayRaw from a manifest section.
 
         Args:
-            section (AssayRawManifestSection): The manifest section
+            section: The manifest section
                 describing the raw assay data.
 
         Returns:
@@ -358,7 +358,7 @@ class AssayRaw:
         """Converts the AssayRaw to a manifest section.
 
         Args:
-            path (Path): The path to the raw assay file.
+            path: The path to the raw assay file.
 
         Returns:
             AssayRawManifestSection: The manifest section representing
@@ -380,9 +380,9 @@ class AssayRaw:
         """Dump the raw assay data to a file.
 
         Args:
-            path (Path, optional): The output directory to dump the raw assay
+            path: The output directory to dump the raw assay
                 file in. If None, the current working directory is used.
-            fmt (AssayRawFormat, optional): The file format. Defaults to
+            fmt: The file format. Defaults to
                 AssayRawFormat.CSV.
 
         Raises:
@@ -405,7 +405,7 @@ class AssayRaw:
         """Returns the assay records as a Polars DataFrame.
 
         Args:
-            fields (Collection[str] | None): The fields to include.
+            fields: The fields to include.
                 If None, all fields are included. Defaults to None.
 
         Returns:
@@ -521,7 +521,7 @@ class Assay(AssayRaw):
         """Slice the assay to get a subset.
 
         Args:
-            slc (AssaySlice | list[bool | str]):
+            slc:
                 1. If an AssaySlice is given, it can contain both column names and
                     a boolean mask for the records.
                 2. If a list of strings is given, it is treated as a list of
@@ -636,7 +636,7 @@ class Assay(AssayRaw):
         """Create `AssayManifestSection` from the assay.
 
         Args:
-            path (Path): The path to the assay file.
+            path: The path to the assay file.
 
         Returns:
             AssayManifestSection: The manifest section for the assay.
@@ -665,7 +665,7 @@ class Assay(AssayRaw):
         """Returns the assay records with assay variables as a Polars DataFrame.
 
         Args:
-            target_names (Collection[str] | str | None): The target name(s) to include.
+            target_names: The target name(s) to include.
                 If None, all target names are included. Defaults to None.
 
         Returns:
@@ -713,9 +713,9 @@ class Assay(AssayRaw):
         - CSV (.csv)
 
         Args:
-            path (Path): The output directory to dump the assay file in. If
+            path: The output directory to dump the assay file in. If
                 None, the current working directory is used.
-            fmt (AssayFormat): The file format
+            fmt: The file format
 
         Raises:
             NotImplementedError: if the file type is not supported.

--- a/src/proteingym/base/data_generators.py
+++ b/src/proteingym/base/data_generators.py
@@ -132,9 +132,9 @@ def adjust_target_with_two_dummy_features(
     target_new = target_old * (2 if bar=="a" else -1) - foo/50
 
     Args:
-        df (pl.DataFrame): Input DataFrame containing the target column.
-        target (str): Name of the target column to adjust.
-        feature_names (list[str] | None): Names for the two new features.
+        df: Input DataFrame containing the target column.
+        target: Name of the target column to adjust.
+        feature_names: Names for the two new features.
             Must contain exactly 2 names. Defaults to ["foo", "bar"] if None.
 
     Returns:

--- a/src/proteingym/base/dataset.py
+++ b/src/proteingym/base/dataset.py
@@ -73,7 +73,7 @@ class DatasetSlice:
         This method is useful when deserializing from JSON including the sub-objects.
 
         Args:
-            data (dict[str, Any]): The dictionary to create the dataset slice from.
+            data: The dictionary to create the dataset slice from.
 
         Returns:
             The dataset slice created from the dictionary.
@@ -89,7 +89,7 @@ class DatasetSlice:
         """Create a dataset slice from a JSON string.
 
         Args:
-            contents (str): The JSON string to create the dataset slice from.
+            contents: The JSON string to create the dataset slice from.
 
         Returns:
             The dataset slice created from the JSON string.
@@ -291,7 +291,7 @@ class Dataset(BaseModel):
         """Get a slice of the dataset.
 
         Args:
-            item (slice | DatasetSlice): The slice to get. Can be a standard
+            item: The slice to get. Can be a standard
                 Python slice or a DatasetSlice.
 
         Returns:
@@ -450,7 +450,7 @@ class Dataset(BaseModel):
         Currently supports UniProt (in sequence) and DOI (in publication) identifiers.
 
         Args:
-            overwrite (bool): If True, overwrite existing values.
+            overwrite: If True, overwrite existing values.
                 If False, only fill empty fields.
 
         Returns:
@@ -492,7 +492,7 @@ class Dataset(BaseModel):
         structures, msas, and assays details.
 
         Args:
-            manifest (DatasetManifest): The manifest to create the dataset from.
+            manifest: The manifest to create the dataset from.
 
         Returns:
             Dataset: The dataset created from the manifest.
@@ -584,7 +584,7 @@ class Dataset(BaseModel):
         The manifest contains the metadata and sections for each data type.
 
         Args:
-            data_paths (dict[type, list[Path]]): A dictionary mapping the data
+            data_paths: A dictionary mapping the data
                 type - Sequence, Structure and MSA - to the list of paths to the
                 dumped data.
         """
@@ -682,7 +682,7 @@ class Dataset(BaseModel):
         """Dump the dataset.
 
         Args:
-            path (Path | str | None): The path to dump the dataset in. If None,
+            path: The path to dump the dataset in. If None,
                 the current working directory is used. Defaults to None.
 
         Returns:
@@ -729,7 +729,7 @@ class Dataset(BaseModel):
         """Returns the dataset assay records as a Polars DataFrame.
 
         Args:
-            target_names (Collection[str] | str | None): The target name(s) to include.
+            target_names: The target name(s) to include.
                 If None, all target names are included. Defaults to None.
             agg:
                 Aggregation function or mapping. Can be:
@@ -951,7 +951,7 @@ class Subsets:
         """Get a subset by key.
 
         Args:
-            key (str): The key of the subset to get.
+            key: The key of the subset to get.
 
         Returns:
             Subset: The subset corresponding to the key.
@@ -1002,7 +1002,7 @@ class Subsets:
         """Load the slices from a JSON string.
 
         Args:
-            slices_str (str): The JSON string representation of the slices.
+            slices_str: The JSON string representation of the slices.
         """
         data = json.loads(slices_str)
         if isinstance(data, dict):
@@ -1063,7 +1063,7 @@ class Subsets:
         """Dump the subsets.
 
         Args:
-            path (Path | str | None): The path to dump the dataset in. If None,
+            path: The path to dump the dataset in. If None,
                 the current working directory is used. Defaults to None.
 
         Returns:

--- a/src/proteingym/base/manifest.py
+++ b/src/proteingym/base/manifest.py
@@ -191,7 +191,7 @@ class Manifest(BaseModel):
         manifest path.
 
         Args:
-            path (Path | str | None): The path to dump the manifest to. If None,
+            path: The path to dump the manifest to. If None,
                 the current working directory is used as path. If path is a
                 directory, the manifest name is used as file name. Defaults to None.
 

--- a/src/proteingym/base/msa.py
+++ b/src/proteingym/base/msa.py
@@ -253,7 +253,7 @@ class MSA:
         """Create a manifest section from the MSA instance.
 
         Args:
-            path (Path): The path to the MSA file. As created by the dump method.
+            path: The path to the MSA file. As created by the dump method.
 
         Returns:
             MSAManifestSection: The manifest section for the MSA.
@@ -280,9 +280,9 @@ class MSA:
         :func:`Bio.AlignIO.write` for details.
 
         Args:
-            path (Path | None): The directory path to save the MSA file in.
+            path: The directory path to save the MSA file in.
                 Defaults to the current working directory.
-            fmt (MSAFormat): The format to save the MSA in. Defaults to
+            fmt: The format to save the MSA in. Defaults to
                 MSAFormat.FASTA.
 
         Raises:

--- a/src/proteingym/base/sequence.py
+++ b/src/proteingym/base/sequence.py
@@ -246,7 +246,7 @@ class Sequence:
         """Create Sequence(s) from a sequence manifest section.
 
         Args:
-            section (SequenceManifestSection): The sequence manifest section to create
+            section: The sequence manifest section to create
                 the Sequence from.
 
         Yields:
@@ -270,7 +270,7 @@ class Sequence:
         """Convert the sequence to a manifest section.
 
         Args:
-            path (Path): The path to the sequence file (as created by
+            path: The path to the sequence file (as created by
                 `method:dump`).
 
         Returns:
@@ -297,7 +297,7 @@ class Sequence:
         - FASTQ (.fastq)
 
         Args:
-            path (Path): The output directory path to dump the sequence to. If
+            path: The output directory path to dump the sequence to. If
                 None, the current working directory is used.
             fmt (SequenceFormat): The format to dump the sequence in.
 

--- a/src/proteingym/base/splits.py
+++ b/src/proteingym/base/splits.py
@@ -66,11 +66,11 @@ def _cast_indices_to_mask(indices: list[int], *, length: int) -> list[bool]:
     positions are set to False.
 
     Args:
-        indices (list[int]): List of indices to be set to True.
-        length (int): Length of the resulting mask.
+        indices: List of indices to be set to True.
+        length: Length of the resulting mask.
 
     Returns:
-        list[bool]: Boolean mask with True at the specified indices.
+        list: Boolean mask with True at the specified indices.
     """
     mask = [False] * length
     for index in indices:
@@ -85,8 +85,8 @@ def _reshape_list(flat_list: list, shape: tuple[int, ...]) -> list:
     have the same size and thus the shape contain the size of each dimension.
 
     Args:
-        flat_list (list): The flat list to reshape.
-        shape (tuple[int, ...]): The desired shape.
+        flat_list: The flat list to reshape.
+        shape: The desired shape.
 
     Returns:
         list: The reshaped nested list.
@@ -106,10 +106,10 @@ class RandomSplitter:
     """Randomly split a dataset.
 
     Args:
-        fractions (list[float]): A list of floats representing the fractions.
+        fractions: A list of floats representing the fractions.
             The fractions must sum to 1. Provide two fractions for a train/test split;
             provide three fractions for a train/val/test split.
-        random_state (int | np.random.RandomState | None): Seed or random state for
+        random_state: Seed or random state for
             reproducibility. If None, the global numpy random state is used.
     """
 
@@ -138,8 +138,8 @@ class RandomSplitter:
         assay shapes after converting them into a boolean mask.
 
         Args:
-            dataset (Dataset): The dataset to split.
-            targets (list[str] | None): List of target column names to include in the
+            dataset: The dataset to split.
+            targets: List of target column names to include in the
                 splits. If None, all columns are included.
 
         Returns:
@@ -188,10 +188,10 @@ class KFoldSplitter:
     """Split a dataset into k folds for cross-validation.
 
     Args:
-        n_splits (int): Number of folds. Must be at least 2.
-        shuffle (bool): Whether to shuffle the dataset before splitting.
+        n_splits: Number of folds. Must be at least 2.
+        shuffle: Whether to shuffle the dataset before splitting.
             Defaults to False.
-        random_state (int | np.random.RandomState | None): Seed or random state for
+        random_state: Seed or random state for
             reproducibility. If None, the global numpy random state is used.
     """
 
@@ -218,12 +218,12 @@ class KFoldSplitter:
         the training set.
 
         Args:
-            dataset (Dataset): The dataset to split.
-            targets (list[str] | None): List of target column names to include in the
+            dataset: The dataset to split.
+            targets: List of target column names to include in the
                 splits. If None, all columns are included.
 
         Returns:
-            list[Subsets]: A list of Subsets, where each Subset contains a training set
+            list: A list of Subsets, where each Subset contains a training set
             and a validation set for one fold.
         """
         records_shape = tuple(len(assay) for assay in dataset.assays)

--- a/src/proteingym/base/structure.py
+++ b/src/proteingym/base/structure.py
@@ -155,7 +155,7 @@ class Structure:
         """Convert the structure to a manifest section.
 
         Args:
-            path (Path): The path to the structure file (as created by
+            path: The path to the structure file (as created by
                 `method:dump`).
 
         Returns:
@@ -180,9 +180,9 @@ class Structure:
         Note that binary CIF files (.bcif) are not supported for writing.
 
         Args:
-            path (Path): The output directory path to dump the structure to. If
+            path: The output directory path to dump the structure to. If
                 None, the current working directory is used.
-            fmt (StructureFormat): The format to dump the structure in.
+            fmt: The format to dump the structure in.
 
         Raises:
             NotImplementedError: if the file type is not supported.

--- a/src/proteingym/base/transformers.py
+++ b/src/proteingym/base/transformers.py
@@ -107,9 +107,9 @@ class SequenceOneHotEncoder(BaseEstimator, TransformerMixin):
 
         Returns:
             One-hot encoded matrix of shape (n_samples, n_variant_features).
-            Each sequence is encoded as a flattened matrix where position i and
-            character j are encoded at index (i * alphabet_size + j).
-            Invariant (constant) columns are removed.
+                Each sequence is encoded as a flattened matrix where position i and
+                character j are encoded at index (i * alphabet_size + j).
+                Invariant (constant) columns are removed.
 
         Raises:
             ValueError: If sequences have varying lengths or don't match the expected
@@ -169,7 +169,7 @@ class SequenceOneHotEncoder(BaseEstimator, TransformerMixin):
 
         Returns:
             Array of feature names in the format: column_pos{i}_{char}.
-            Only includes features for variant (non-constant) columns.
+                Only includes features for variant (non-constant) columns.
         """
         feature_names = []
         for pos in range(self.max_length_):


### PR DESCRIPTION
# Changes

MKDocs generates type hints from the docstrings, if there are none present takes these from the type hints in the function description.

No need to double type hints upkeep if we can automatically generate for the documentation.
