### PR TITLE
Field aliases

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -75,12 +75,18 @@ description = "DMS score bin of the samples"
 [[ assays ]]
 name = "assay"
 path = "assay.csv"
-sequence = "sequence"
 sequence_alphabet = "AA"
 
-[ assays.targets ]
-"DMS Score" = "DMS_score"
-"DMS Score Bin" = "DMS_score_bin"
+[ assays.sequence ]
+name = "sequence"
+
+[[ assays.targets ]]
+name = "DMS Score"
+alias = "DMS_score"
+
+[[ assays.targets ]]
+name = "DMS Score Bin"
+alias = "DMS_score_bin"
 
 [ assays.variables ]
 PH = 7

--- a/example_data/neime_2019.toml
+++ b/example_data/neime_2019.toml
@@ -2,6 +2,9 @@ name = "NEIME_2019"
 description = "The NEIME Kennouche 2019 (UniProt id: A0A1I9GEU1) datase"
 version = "1.0.0"
 
+[publication]
+doi = "10.15252/embj.2019102145"
+
 [[ assay_variables ]]
 name = "PH"
 description = "pH level of the samples"
@@ -23,13 +26,20 @@ description = "DMS score bin of the samples"
 
 [[ assays ]]
 name = "NEIME_2019"
-sequence = "mutated_sequence"
 path = "./NEIME_2019/Assays/Assay1.csv"
 sequence_alphabet = "AA"
 
-[ assays.targets ]
-"DMS Score" = "DMS_score"
-"DMS Score Bin" = "DMS_score_bin"
+[ assays.sequence ]
+name = "sequence"
+alias = "mutated_sequence"
+
+[[ assays.targets ]]
+name = "DMS Score"
+alias = "DMS_score"
+
+[[ assays.targets ]]
+name = "DMS Score Bin"
+alias = "DMS_score_bin"
 
 [ assays.variables ]
 T = 37
@@ -39,6 +49,7 @@ PH = 7
 path = "./NEIME_2019/sequences/A0A1I9GEU1.fasta"
 type = "wild_type"
 alphabet = "AA"
+uniprot_id = "A0A1I9GEU1"
 
 [[ structures ]]
 path = "./NEIME_2019/Structures/computational.pdb"

--- a/notebooks/02_Creating_Manifests_and_Archives.ipynb
+++ b/notebooks/02_Creating_Manifests_and_Archives.ipynb
@@ -25,8 +25,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-10T11:52:24.134423Z",
+     "start_time": "2025-12-10T11:52:24.124957Z"
+    }
+   },
+   "source": [
+    "# First, let's look at the example manifest\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Read the example manifest\n",
+    "manifest_path = Path(\"../example_data/neime_2019.toml\")\n",
+    "manifest_content = manifest_path.read_text(encoding=\"utf-8\")\n",
+    "\n",
+    "print(manifest_content)"
+   ],
    "outputs": [
     {
      "name": "stdout",
@@ -35,6 +49,9 @@
       "name = \"NEIME_2019\"\n",
       "description = \"The NEIME Kennouche 2019 (UniProt id: A0A1I9GEU1) datase\"\n",
       "version = \"1.0.0\"\n",
+      "\n",
+      "[publication]\n",
+      "doi = \"10.15252/embj.2019102145\"\n",
       "\n",
       "[[ assay_variables ]]\n",
       "name = \"PH\"\n",
@@ -56,12 +73,21 @@
       "description = \"DMS score bin of the samples\"\n",
       "\n",
       "[[ assays ]]\n",
-      "sequence = \"mutated_sequence\"\n",
+      "name = \"NEIME_2019\"\n",
       "path = \"./NEIME_2019/Assays/Assay1.csv\"\n",
       "sequence_alphabet = \"AA\"\n",
       "\n",
-      "[ assays.targets ]\n",
-      "\"DMS Score\" = \"DMS_score\"\n",
+      "[ assays.sequence ]\n",
+      "name = \"sequence\"\n",
+      "alias = \"mutated_sequence\"\n",
+      "\n",
+      "[[ assays.targets ]]\n",
+      "name = \"DMS Score\"\n",
+      "alias = \"DMS_score\"\n",
+      "\n",
+      "[[ assays.targets ]]\n",
+      "name = \"DMS Score Bin\"\n",
+      "alias = \"DMS_score_bin\"\n",
       "\n",
       "[ assays.variables ]\n",
       "T = 37\n",
@@ -89,16 +115,7 @@
      ]
     }
    ],
-   "source": [
-    "# First, let's look at the example manifest\n",
-    "from pathlib import Path\n",
-    "\n",
-    "# Read the example manifest\n",
-    "manifest_path = Path(\"../example_data/neime_2019.toml\")\n",
-    "manifest_content = manifest_path.read_text(encoding=\"utf-8\")\n",
-    "\n",
-    "print(manifest_content)"
-   ]
+   "execution_count": 1
   },
   {
    "cell_type": "markdown",
@@ -402,13 +419,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-10T11:54:21.157491Z",
+     "start_time": "2025-12-10T11:54:21.153729Z"
+    }
+   },
    "source": [
     "complete_manifest = \"\"\"version = \"1.0.0\"\n",
     "name = \"NEIME_2019\"\n",
     "description = \"NEIME enzyme dataset from Kennouche et al. 2019 with DMS scores\"\n",
+    "\n",
+    "[publication]\n",
+    "doi = \"10.15252/embj.2019102145\"\n",
     "\n",
     "[[ assay_variables ]]\n",
     "name = \"T\"\n",
@@ -431,13 +454,20 @@
     "\n",
     "[[ assays ]]\n",
     "name = \"NEIME_2019\"\n",
-    "sequence = \"mutated_sequence\"\n",
     "path = \"./NEIME_2019/Assays/Assay1.csv\"\n",
     "sequence_alphabet = \"AA\"\n",
     "\n",
-    "[ assays.targets ]\n",
-    "\"DMS Score\" = \"DMS_score\"\n",
-    "\"DMS Score Bin\" = \"DMS_score_bin\"\n",
+    "[ assays.sequence ]\n",
+    "name = \"sequence\"\n",
+    "alias = \"mutated_sequence\"\n",
+    "\n",
+    "[[ assays.targets ]]\n",
+    "name = \"DMS Score\"\n",
+    "alias = \"DMS_score\"\n",
+    "\n",
+    "[[ assays.targets ]]\n",
+    "name = \"DMS Score Bin\"\n",
+    "alias = \"DMS_score_bin\"\n",
     "\n",
     "[ assays.variables ]\n",
     "pH = 7\n",
@@ -468,12 +498,29 @@
     "[ msas.metadata ]\n",
     "software = \"mmseqs2\"\n",
     "sequence_identity = \"30%\" \"\"\""
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 3
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-10T11:54:28.441166Z",
+     "start_time": "2025-12-10T11:54:28.435799Z"
+    }
+   },
+   "source": [
+    "# Write the complete manifest\n",
+    "output_path = Path(\"../example_data/neime_2019_complete.toml\")\n",
+    "output_path.write_text(complete_manifest, encoding=\"utf-8\")\n",
+    "\n",
+    "print(f\"Complete manifest written to: {output_path}\")\n",
+    "\n",
+    "# Display the written content\n",
+    "print(\"\\nGenerated manifest:\")\n",
+    "print(output_path.read_text(encoding=\"utf-8\"))"
+   ],
    "outputs": [
     {
      "name": "stdout",
@@ -485,6 +532,9 @@
       "version = \"1.0.0\"\n",
       "name = \"NEIME_2019\"\n",
       "description = \"NEIME enzyme dataset from Kennouche et al. 2019 with DMS scores\"\n",
+      "\n",
+      "[publication]\n",
+      "doi = \"10.15252/embj.2019102145\"\n",
       "\n",
       "[[ assay_variables ]]\n",
       "name = \"T\"\n",
@@ -506,13 +556,21 @@
       "description = \"Binned DMS score\"\n",
       "\n",
       "[[ assays ]]\n",
-      "sequence = \"mutated_sequence\"\n",
+      "name = \"NEIME_2019\"\n",
       "path = \"./NEIME_2019/Assays/Assay1.csv\"\n",
       "sequence_alphabet = \"AA\"\n",
       "\n",
-      "[ assays.targets ]\n",
-      "\"DMS Score\" = \"DMS_score\"\n",
-      "\"DMS Score Bin\" = \"DMS_score_bin\"\n",
+      "[ assays.sequence ]\n",
+      "name = \"sequence\"\n",
+      "alias = \"mutated_sequence\"\n",
+      "\n",
+      "[[ assays.targets ]]\n",
+      "name = \"DMS Score\"\n",
+      "alias = \"DMS_score\"\n",
+      "\n",
+      "[[ assays.targets ]]\n",
+      "name = \"DMS Score Bin\"\n",
+      "alias = \"DMS_score_bin\"\n",
       "\n",
       "[ assays.variables ]\n",
       "pH = 7\n",
@@ -546,17 +604,7 @@
      ]
     }
    ],
-   "source": [
-    "# Write the complete manifest\n",
-    "output_path = Path(\"../example_data/neime_2019_complete.toml\")\n",
-    "output_path.write_text(complete_manifest, encoding=\"utf-8\")\n",
-    "\n",
-    "print(f\"Complete manifest written to: {output_path}\")\n",
-    "\n",
-    "# Display the written content\n",
-    "print(\"\\nGenerated manifest:\")\n",
-    "print(output_path.read_text(encoding=\"utf-8\"))"
-   ]
+   "execution_count": 4
   },
   {
    "cell_type": "markdown",
@@ -569,8 +617,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-10T11:54:35.352818Z",
+     "start_time": "2025-12-10T11:54:34.594726Z"
+    }
+   },
+   "source": [
+    "from proteingym.base import Manifest, Dataset\n",
+    "\n",
+    "# Load the manifest\n",
+    "manifest = Manifest.from_path(output_path)\n",
+    "\n",
+    "print(f\"Loaded manifest: {manifest.name}\")\n",
+    "print(f\"Description: {manifest.description}\")\n",
+    "print(f\"Version: {manifest.version}\")\n",
+    "print(f\"Number of assays: {len(manifest.assays)}\")\n",
+    "print(f\"Number of sequences: {len(manifest.sequences)}\")\n",
+    "print(f\"Number of structures: {len(manifest.structures)}\")\n",
+    "print(f\"Number of MSAs: {len(manifest.msas)}\")\n",
+    "print(f\"Number of assay variables: {len(manifest.assay_variables)}\")"
+   ],
    "outputs": [
     {
      "name": "stdout",
@@ -587,21 +654,45 @@
      ]
     }
    ],
-   "source": [
-    "from proteingym.base import Manifest, Dataset\n",
-    "\n",
-    "# Load the manifest\n",
-    "manifest = Manifest.from_path(output_path)\n",
-    "\n",
-    "print(f\"Loaded manifest: {manifest.name}\")\n",
-    "print(f\"Description: {manifest.description}\")\n",
-    "print(f\"Version: {manifest.version}\")\n",
-    "print(f\"Number of assays: {len(manifest.assays)}\")\n",
-    "print(f\"Number of sequences: {len(manifest.sequences)}\")\n",
-    "print(f\"Number of structures: {len(manifest.structures)}\")\n",
-    "print(f\"Number of MSAs: {len(manifest.msas)}\")\n",
-    "print(f\"Number of assay variables: {len(manifest.assay_variables)}\")"
-   ]
+   "execution_count": 5
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Note that while we only passed the doi on the publication, remaining details such as title and authors get populated automatically when we request the those properties."
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-12-10T11:54:46.288650Z",
+     "start_time": "2025-12-10T11:54:45.609477Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "manifest.publication",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Publication(\n",
+       "\ttitle: Deep mutational scanning of the\n",
+       "                    Neisseri..., \n",
+       "\tauthor: Kennouche, Paul and Charles‐Orszag, Arthur and Nishiguchi, D..., \n",
+       "\tjournal: The EMBO Journal, \n",
+       "\tvolume: 38, \n",
+       "\tnumber: 22, \n",
+       "\tyear: 2019, \n",
+       "\tpages: None, \n",
+       "\tdoi: 10.15252/embj.2019102145, \n",
+       ")"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 6
   },
   {
    "cell_type": "markdown",
@@ -862,8 +953,8 @@
     "assays = [\n",
     "    AssayManifestSection(\n",
     "        name=\"NEIME_2019\",\n",
-    "        sequence=\"mutated_sequence\",\n",
-    "        targets={\"DMS Score\": \"DMS_score\", \"DMS Score Bin\": \"DMS_score_bin\"},\n",
+    "        sequence=Field(name=\"mutated_sequence\"),\n",
+    "        targets=[Field(name=\"DMS Score\", alias=\"DMS_score\"), Field(name=\"DMS Score Bin\", alias=\"DMS_score_bin\")],\n",
     "        sequence_alphabet=\"AA\",\n",
     "        path=Path(\"../example_data/NEIME_2019/Assays/Assay1.csv\"),\n",
     "    )\n",
@@ -926,6 +1017,13 @@
     "    )\n",
     "]"
    ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": ""
   },
   {
    "cell_type": "markdown",

--- a/notebooks/04_Data_Access_for_ML.ipynb
+++ b/notebooks/04_Data_Access_for_ML.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Lets grab a dataset for showcasing\n",
+    "# Let's grab a dataset for showcasing\n",
     "\n",
     "from proteingym.base import Dataset, Manifest\n",
     "\n",

--- a/src/proteingym/base/assay.py
+++ b/src/proteingym/base/assay.py
@@ -34,7 +34,7 @@ class AssayFormat(StrEnum):
     """A comma separated text file"""
 
 
-@dataclasses.dataclass(kw_only=True, frozen=True)
+@dataclasses.dataclass(kw_only=True, frozen=False)
 class Field:
     """A data field for an assay associated quantity or protein property.
 
@@ -57,6 +57,42 @@ class Field:
 
     description: str | None = None
     """Description of the field."""
+
+    alias: str | None = None
+    """An alias for this field.
+
+    Example use is when a field is referred to be a different name in an input csv file.
+    """
+
+    def fill_from_parent(self, parent: "Field") -> None:
+        """Fill value, unit and description this field from another field.
+
+        Raises:
+            ValueError if names do not match (expected for parent / child) relationship.
+            ValueError if an attribute is set of self but differs on parent.
+        """
+        if self.name != parent.name:
+            raise ValueError("Expected names to match")
+        for attr in ("value", "unit", "description"):
+            own = getattr(self, attr)
+            if own is not None and own != getattr(parent, attr):
+                raise ValueError(f"Attribute {attr} for field {self.name} redefined")
+            setattr(self, attr, getattr(parent, attr))
+
+    def without_alias(self) -> "Field":
+        """Get a Field identical to this one but without its alias."""
+        return Field(
+            name=self.name,
+            value=self.value,
+            unit=self.unit,
+            description=self.description,
+        )
+
+    @property
+    def alias_(self) -> str:
+        """Get the alias for this field (i.e., name if no alias available)."""
+        # The obvious getter/setter pattern is not compatible with dataclasses
+        return self.name if self.alias is None else self.alias
 
     def __eq__(self, other: "Field") -> bool:
         """Implements the '==' operator for Field."""
@@ -93,7 +129,7 @@ class _ManifestSection(BaseModel):
 
     model_config = ConfigDict(
         extra="forbid",
-        frozen=True,
+        frozen=False,
         use_attribute_docstrings=True,
         str_min_length=1,
     )
@@ -175,17 +211,14 @@ class AssayManifestSection(_ManifestSection):
     )
     """Configuration for the Pydantic model."""
 
-    # TODO: make this sequence_alias instead?
-    sequence: str = "sequence"
+    sequence: Field = pydantic.Field(default_factory=lambda: Field(name="sequence"))
     """The sequence feature name given in the file."""
 
     sequence_alphabet: SequenceAlphabet | None = None
     """The alphabet of the sequences of the assay."""
 
-    # TODO: make this a list instead and also include 'field_aliases' as more explicit
-    #  mapping?
-    targets: dict[str, str] = pydantic.Field(default_factory=dict)
-    """The map of target names in dataset to target feature names in assay."""
+    targets: list[Field] = pydantic.Field(default_factory=list)
+    """The list of prediction targets in this assay."""
 
     variables: dict[str, bool | int | float | str] = pydantic.Field(
         default_factory=dict
@@ -197,11 +230,13 @@ class AssayManifestSection(_ManifestSection):
     """The path to the assay file, csv only."""
 
     @model_validator(mode="after")
-    def validate_feature_names(self) -> "AssayManifestSection":
-        """Validate whether feature names are present in the `path` file."""
-        for v in [self.sequence] + list(self.targets.values()):
-            if v not in self._header:
-                raise ValueError(f"Feature '{v}' not found in the file: {self.path}")
+    def validate_fields(self) -> "AssayManifestSection":
+        """Validate whether field names are present in the `path` file."""
+        for v in [self.sequence] + self.targets:
+            if v.alias_ not in self._header:
+                raise ValueError(
+                    f"Feature '{v.name}' not found in the file: {self.path}"
+                )
         return self
 
     @field_serializer("sequence_alphabet")
@@ -537,13 +572,14 @@ class Assay(AssayRaw):
         """Create an Assay instance from a manifest section."""
 
         df = pl.read_csv(
-            section.path, columns=[section.sequence] + list(section.targets.values())
+            section.path,
+            columns=[section.sequence.alias_] + [f.alias_ for f in section.targets],
         )
         df = df.with_columns(
             # Sequences are created from sequence strings present in the file
             # The sequence name is taken from the string itself as the name is not
             # provided in the assay file.
-            pl.col(section.sequence)
+            pl.col(section.sequence.alias_)
             .map_elements(
                 lambda seq: Sequence(
                     # The type of the sequence is set to "standard". This would be
@@ -558,16 +594,15 @@ class Assay(AssayRaw):
             .alias("sequence_object")
         )
         records = list(
-            df.select("sequence_object", *section.targets.values()).iter_rows()
+            df.select(
+                "sequence_object", *[f.alias_ for f in section.targets]
+            ).iter_rows()
         )
 
-        fields = [
-            Field(name=f) for f in [section.sequence] + list(section.targets.keys())
-        ]
         return cls(
             name=section.name or section.path.stem,
             records=records,
-            fields=fields,
+            fields=[section.sequence] + section.targets,
             description=section.description,
             variables=section.variables,
         )
@@ -590,11 +625,9 @@ class Assay(AssayRaw):
         return AssayManifestSection(
             name=self.name,
             description=self.description,
-            sequence=self.sequence_feature_name,
+            sequence=self.fields[0].without_alias(),
             sequence_alphabet=sequence_alphabet,
-            targets=dict(
-                zip(self.target_feature_names, self.target_feature_names, strict=False)
-            ),
+            targets=[f.without_alias() for f in self.fields[1:]],
             variables=self.variables,
             path=path,
         )

--- a/src/proteingym/base/manifest.py
+++ b/src/proteingym/base/manifest.py
@@ -156,15 +156,20 @@ class Manifest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_assay_targets(self) -> "Manifest":
-        """Validate that all assay targets are defined in the manifest."""
-        defined_target_names = {target.name for target in self.assay_targets}
+        """Validate that all assay targets are defined in the manifest.
+
+        Fill assay target (fields) with properties from the target defined at the top
+        level.
+        """
+        targets = {t.name: t for t in self.assay_targets}
         for assay in self.assays:
-            undefined_target_names = set(assay.targets.keys()) - defined_target_names
-            if undefined_target_names:
-                raise ValueError(
-                    f"Assay {assay.name} contains undefined targets:"
-                    f"{undefined_target_names}"
-                )
+            for t in assay.targets:
+                try:
+                    t.fill_from_parent(targets[t.name])
+                except KeyError as e:
+                    raise ValueError(
+                        f"Assay {assay.name} contains undefined target: {str(e)}"
+                    ) from e
         return self
 
     @classmethod

--- a/tests/test_assay.py
+++ b/tests/test_assay.py
@@ -97,6 +97,7 @@ def test_field_complete() -> None:
             name="field",
             value=42,
             unit="log",
+            alias="foo",
             description="A test field",
         )
     except ValidationError as e:
@@ -105,9 +106,40 @@ def test_field_complete() -> None:
         assert (
             field.name == "field"
             and field.value == 42
+            and field.alias == "foo"
             and field.unit == "log"
             and field.description == "A test field"
         )
+
+
+def test_field_alias_():
+    """The alias_ if a field is the name if alias not available."""
+    assert (
+        Field(name="foo").alias_ == "foo"
+        and Field(name="foo", alias="bar").alias_ == "bar"
+    )
+
+
+def test_field_fill_from_parent():
+    parent = Field(name="foo", unit="kg")
+    child = Field(name="foo")
+    child.fill_from_parent(parent)
+    assert child.unit == "kg"
+
+
+def test_field_fill_from_parent_names_must_match():
+    parent = Field(name="foo", unit="kg")
+    child = Field(name="bar")
+    with pytest.raises(ValueError):
+        child.fill_from_parent(parent)
+
+
+def test_field_fill_from_parent_must_not_redefine():
+    """Must"""
+    parent = Field(name="foo", unit="kg")
+    child = Field(name="foo", unit="g")
+    with pytest.raises(ValueError, match="Attribute unit for field foo redefined"):
+        child.fill_from_parent(parent)
 
 
 @pytest.mark.parametrize(
@@ -219,6 +251,15 @@ def test_assay_raw_manifest_section_minimal(assay_raw_file: Path) -> None:
         )
 
 
+def test_fields_work_as_expected_in_lists():
+    """Should be able to test if a field is in a list of fields."""
+    fields = [Field(name="foo"), Field(name="bar", unit="g")]
+    assert (
+        Field(name="bar", unit="g") in fields
+        and Field(name="foo", unit="g") not in fields
+    )
+
+
 def test_assay_raw_manifest_section_with_relative_path(assay_raw_file: Path) -> None:
     """The can also be created with a relative path."""
     context = {"relative_to_path": assay_raw_file.parent}
@@ -267,9 +308,12 @@ def test_assay_manifest_section(assay_file: Path) -> None:
         section = AssayManifestSection(
             name="test_assay",
             description="Test assay",
-            sequence="sequence",
+            sequence=Field(name="sequence"),
             sequence_alphabet=SequenceAlphabet.AA,
-            targets={"DMS Score": "target", "DMS Score2": "target2"},
+            targets=[
+                Field(name="DMS Score", alias="target"),
+                Field(name="DMS Score2", alias="target2"),
+            ],
             variables={"test_cond1": "true", "test_cond2": 42},
             path=assay_file,
         )
@@ -280,8 +324,8 @@ def test_assay_manifest_section(assay_file: Path) -> None:
         assert isinstance(section.path, Path)
         with assay_file.open() as f:
             content = f.read()
-        assert section.sequence in content
-        assert all(target in content for target in section.targets.values())
+        assert section.sequence.alias_ in content
+        assert all(target.alias_ in content for target in section.targets)
 
 
 def test_assay_manifest_section_with_relative_path(tmp_path: Path) -> None:
@@ -305,9 +349,9 @@ def test_assay_manifest_section_validate_feature_names(assay_file: Path) -> None
         AssayManifestSection(
             name="test_assay",
             description="Test assay",
-            sequence="invalid_feature",
+            sequence=Field(name="invalid_feature"),
             sequence_alphabet=SequenceAlphabet.AA,  # noqa
-            targets={"DMS Score": "invalid_feature"},
+            targets=[Field(name="DMS Score", alias="invalid_feature")],
             variables={"test_cond1": "true", "test_cond2": 42},
             path=assay_file,
         )
@@ -508,9 +552,12 @@ def test_assay_from_manifest_section(assay_file: Path) -> None:
         assay = Assay.from_manifest_section(
             AssayManifestSection(
                 name="assay",
-                sequence="sequence",
+                sequence=Field(name="sequence"),
                 sequence_alphabet=SequenceAlphabet.DNA,
-                targets={"DMS Score": "target", "DMS Score2": "target2"},
+                targets=[
+                    Field(name="DMS Score", alias="target"),
+                    Field(name="DMS Score2", alias="target2"),
+                ],
                 path=assay_file,
                 variables={"test_cond1": "true", "test_cond2": 42},
             ),
@@ -786,7 +833,10 @@ def test_manifest_with_valid_assay_targets(assay_file: Path) -> None:
                     "name": "assay",
                     "path": assay_file,
                     "sequence_alphabet": SequenceAlphabet.DNA,
-                    "targets": {"DMS Score": "target", "DMS Score2": "target2"},
+                    "targets": [
+                        {"name": "DMS Score", "alias": "target"},
+                        {"name": "DMS Score2", "alias": "target2"},
+                    ],
                 }
             ],
         )
@@ -796,12 +846,61 @@ def test_manifest_with_valid_assay_targets(assay_file: Path) -> None:
         assert manifest.assay_targets, "Valid assay targets should be present"
 
 
+def test_manifest_assay_targets_populated_from_parent_targets(assay_file: Path) -> None:
+    """Attribute unit, description copied to assay's targets."""
+    manifest = Manifest(
+        version=Version(1, 0),
+        name="test_manifest",
+        assay_targets=[
+            Field(name="DMS Score", unit="kg", description="foo"),
+        ],
+        assays=[  # noqa
+            {
+                "name": "assay",
+                "path": assay_file,
+                "sequence_alphabet": SequenceAlphabet.DNA,
+                "targets": [
+                    {"name": "DMS Score", "alias": "target"},
+                ],
+            }
+        ],
+    )
+    [target] = manifest.assays[0].targets
+    assert target.unit == "kg" and target.description == "foo"
+
+
+def test_manifest_assay_must_not_redefine_targets(assay_file: Path) -> None:
+    """Test creating a Manifest with undefined assay targets."""
+    with pytest.raises(
+        ValidationError,
+        match=r"validation error for Manifest\n"
+        r".*Value error, Attribute .* for field .* redefined.*",
+    ):
+        Manifest(
+            version=Version(1, 0),
+            name="test_manifest",
+            assay_targets=[
+                Field(name="yield", unit="g"),
+            ],
+            assays=[  # noqa
+                {
+                    "name": "assay",
+                    "path": assay_file,
+                    "sequence_alphabet": SequenceAlphabet.DNA,
+                    "targets": [
+                        {"name": "yield", "alias": "target", "unit": "kg"},
+                    ],
+                }
+            ],
+        )
+
+
 def test_manifest_with_undefined_assay_target(assay_file: Path) -> None:
     """Test creating a Manifest with undefined assay targets."""
     with pytest.raises(
         ValidationError,
         match=r"validation error for Manifest\n"
-        r".*Value error, Assay .* contains undefined targets",
+        r".*Value error, Assay .* contains undefined target.*",
     ):
         Manifest(
             version=Version(1, 0),
@@ -814,7 +913,10 @@ def test_manifest_with_undefined_assay_target(assay_file: Path) -> None:
                     "name": "assay",
                     "path": assay_file,
                     "sequence_alphabet": SequenceAlphabet.DNA,
-                    "targets": {"DMS Score": "target", "DMS Score2": "target2"},
+                    "targets": [
+                        {"name": "DMS Score", "alias": "target"},
+                        {"name": "DMS Score2", "alias": "target2"},
+                    ],
                 }
             ],
         )

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -32,12 +32,18 @@ description = "DMS score bin of the samples"
 [[ assays ]]
 name = "assay"
 path = "assay.csv"
-sequence = "sequence"
 sequence_alphabet = "AA"
 
-[ assays.targets ]
-"DMS Score" = "DMS_score"
-"DMS Score Bin" = "DMS_score_bin"
+[ assays.sequence ]
+name = "sequence"
+
+[[ assays.targets ]]
+name = "DMS Score"
+alias = "DMS_score"
+
+[[ assays.targets ]]
+name = "DMS Score Bin"
+alias = "DMS_score_bin"
 
 [ assays.variables ]
 PH = 7


### PR DESCRIPTION
# Changes

Resolves #406 

Let's make it more clear what we mean with these mappings by making assay targets proper fields, with optional aliases for finding columns in data file, and let them inherit data from the targets defined at top level.

Sadly I conclude that this implies `Field` can no longer be frozen (unless we want to redefine all members each time [unit, description etc]) and not only name and alias. This has no immediate consequences but admittedly a bit of a smell :| 

Alternatives

- Redeclare fields exactly everywhere: confusing and clunky
- Allow for redeclaring unit: No, we want assay data for the same target to be combinable as is. Allowing one to set one unit in one assay and another in another assay for the same target is dangerous
- Automatically inherit unit from top level assay target, raise exception if redeclared: Works but fields can then no longer be frozen

# Checklist

- [ ] I broke the PR down so that it contains a reasonable amount of changes for an effective review
- [x] I performed a self-review of my code. Amongst other things, I have commented my code in hard-to-understand areas.
- [x] I made corresponding changes to the documentation
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I accounted for dependent changes to be merged and published in downstream modules
