### PR TITLE
refactor: provide only alias for sequence instead of whole field

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -7,7 +7,7 @@ The manifest defines how a dataset is constructed.
 The following capabilities have been identified:
 
 | Capability           | Kind           | Motivation                                                |
-| -------------------- | -------------- | --------------------------------------------------------- |
+|----------------------|----------------|-----------------------------------------------------------|
 | Primitive data types | Functional     | For data representation, like `int`, `bool` and `string`. |
 | Lists                | Functional     | For organizing data entries.                              |
 | Maps                 | Functional     | For organizing data entries.                              |
@@ -21,7 +21,7 @@ The following capabilities have been identified:
 Additionally, we defined:
 
 | Kind           | Description                                                                                                     |
-| -------------- | --------------------------------------------------------------------------------------------------------------- |
+|----------------|-----------------------------------------------------------------------------------------------------------------|
 | Functional     | The capability is directly related to the dataset's functionality and is essential for its operation            |
 | Non-functional | The capability is not directly related to the dataset's functionality but enhances usability or maintainability |
 | Domain         | The capability is specific to the domain of the dataset, such as biological data types.                         |
@@ -29,22 +29,22 @@ Additionally, we defined:
 ## TOML Medium
 
 The manifest is defined in [TOML](https://toml.io/en/) format, which is a
-human-readable data serialization language. Below tables motivate the coice of
+human-readable data serialization language. Below tables motivate the choice of
 TOML as the medium for the manifest.
 
 | Criteria           | Minimum | Motivation                                          |
-| ------------------ | ------- | --------------------------------------------------- |
+|--------------------|---------|-----------------------------------------------------|
 | Covers requirement | Yes     | The medium should cover the criteria                |
 | Text based         | No      | Works well with line-diffs in source control (git). |
 | Industry standard  | No      | Easier for user to adopt.                           |
 
 | Minimum criteria | Description                    |
-| ---------------- | ------------------------------ |
+|------------------|--------------------------------|
 | Yes              | The criteria is **required**.  |
 | No               | The criteria is **preferred**. |
 
 | Medium | Covers criteria | Text based | Industry standard |
-| ------ | --------------- | ---------- | ----------------- |
+|--------|-----------------|------------|-------------------|
 | TOML   | Yes             | Yes        | Yes               |
 
 ## Schema
@@ -77,9 +77,6 @@ description = "DMS score bin of the samples"
 name = "assay"
 path = "assay.csv"
 sequence_alphabet = "AA"
-
-[ assays.sequence ]
-name = "sequence"
 
 [[ assays.targets ]]
 name = "DMS Score"
@@ -144,7 +141,7 @@ the protein data types.
 The assay variables section contains a list of assay variables defined in the dataset. E.g., the pH a certain assay was run at, or the round of engineering that an assay belonged to.
 
 | **Field**     | **Type**                              | **Required** | **Default** | **Description**            |
-| ------------- | ------------------------------------- | ------------ | ----------- | -------------------------- |
+|---------------|---------------------------------------|--------------|-------------|----------------------------|
 | `name`        | `string`                              | Yes          | N/A         | The assay variable name    |
 | `description` | `string \| None`                      | No           | `None`      | A brief description.       |
 | `unit`        | `string \| None`                      | No           | `None`      | The unit of measurement.   |
@@ -155,7 +152,7 @@ The assay variables section contains a list of assay variables defined in the da
 The assay targets section contains a list of assay targets defined in the dataset. E.g., the target measured in a certain assay, like binding affinity or stability.
 
 | **Field**     | **Type**                              | **Required** | **Default** | **Description**          |
-| ------------- | ------------------------------------- | ------------ | ----------- | ------------------------ |
+|---------------|---------------------------------------|--------------|-------------|--------------------------|
 | `name`        | `string`                              | Yes          | N/A         | The assay target name    |
 | `description` | `string \| None`                      | No           | `None`      | A brief description.     |
 | `unit`        | `string \| None`                      | No           | `None`      | The unit of measurement. |
@@ -166,11 +163,11 @@ The assay targets section contains a list of assay targets defined in the datase
 The assays section contains a list of assays included in the dataset.
 
 | **Field**           | **Type**         | **Required** | **Default**  | **Description**                                                          |
-| ------------------- | ---------------- | ------------ | ------------ | ------------------------------------------------------------------------ |
+|---------------------|------------------|--------------|--------------|--------------------------------------------------------------------------|
 | `name`              | `string`         | No           | `None`       | The name of the assay.                                                   |
 | `path`              | `string`         | Yes          | N/A          | The path to the assay data file. Supported extensions: `.csv`.           |
 | `targets`           | `dict[str, str]` | Yes          | N/A          | The map of target names given in manifest to feature names in the assay. |
-| `sequence`          | `string`         | No           | `"sequence"` | The sequence feature name in the assay.                                  |
+| `sequence_alias`    | `string`         | No           | `"sequence"` | The name of the column with sequences in the provided data.              |
 | `sequence_alphabet` | `string`         | Yes          | `"AA"`       | The alphabet of the sequence ("DNA", "RNA", or "AA").                    |
 | `variables`         | `dict[str, str]` | No           | Empty dict   | The variables of the assay.                                              |
 
@@ -199,8 +196,8 @@ specific targets. The raw assays are optional, though, if present, they need to
 be linked to an assay.
 
 | **Field**     | **Type**         | **Required** | **Default** | **Description**                                                |
-| ------------- | ---------------- | ------------ | ----------- | -------------------------------------------------------------- |
-| `name`        | `string`         | Yes          | `None`      | The name of the assay the raw data belongs to.              |
+|---------------|------------------|--------------|-------------|----------------------------------------------------------------|
+| `name`        | `string`         | Yes          | `None`      | The name of the assay the raw data belongs to.                 |
 | `path`        | `string`         | Yes          | N/A         | The path to the assay data file. Supported extensions: `.csv`. |
 | `description` | `string \| None` | No           | `None`      | A brief description.                                           |
 
@@ -209,7 +206,7 @@ be linked to an assay.
 The fields section defines the fields in the raw assay data file.
 
 | **Field**     | **Type**                              | **Required** | **Default** | **Description**            |
-| ------------- | ------------------------------------- | ------------ | ----------- | -------------------------- |
+|---------------|---------------------------------------|--------------|-------------|----------------------------|
 | `name`        | `string`                              | Yes          | N/A         | The field name             |
 | `description` | `string \| None`                      | No           | `None`      | A brief description.       |
 | `unit`        | `string \| None`                      | No           | `None`      | The unit of measurement.   |
@@ -220,7 +217,7 @@ The fields section defines the fields in the raw assay data file.
 The sequences section contains a list of sequences included in the dataset.
 
 | **Field**  | **Type**         | **Required** | **Default** | **Description**                                                                                                                                                     |
-| ---------- | ---------------- | ------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|------------|------------------|--------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `path`     | `string`         | Yes          | N/A         | The path to the sequence data file or directory. In case of directories, all files within the directory will be included. Supported extensions: `.fasta`, `.fastq`. |
 | `alphabet` | `string`         | Yes          | N/A         | The alphabet of the sequence (e.g., "DNA", "RNA", "AA").                                                                                                            |
 | `type`     | `string` \| None | No           | None        | The type of the sequence (e.g., "wild_type", "starting_sequence", "engineered_sequence").                                                                           |
@@ -230,24 +227,24 @@ The sequences section contains a list of sequences included in the dataset.
 The structures section contains a list of structures included in the dataset.
 
 | **Field** | **Type** | **Required** | **Default** | **Description**                                                                                                                                                           |
-| --------- | -------- | ------------ | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|-----------|----------|--------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `path`    | `string` | Yes          | N/A         | The path to the structure data file or directory. In case of directories, all files within the directory will be included. Supported extensions: `.pdb`, `.cif`, `.bcif`. |
 
 ### MSAs
 
 The MSAs section contains a list of multiple sequence alignments included in the dataset.
 
-| **Field**            | **Type**              | **Required** | **Default** | **Description**                                                                                                                                            |
-| -------------------- | --------------------- | ------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `path`               | `string`              | Yes          | N/A         | The path to the MSA data file or directory. In case of directories, all files within the directory will be included. Supported extensions: `.a3m`, `.msa`. |
-| `format`             | `string`              | No           | `"fasta"`   | The format of the MSA data. Supported formats: `"fasta"`                                                                                                   |
-| `num_significant`    | `int` \| None         | No           | `None`      | The number of significant sequences to include in the MSA.                                                                                                 |
-| `bit_score`          | `float` \| None       | No           | `None`      | The bit score threshold for including sequences in the MSA.                                                                                                |
-| `theta`              | `float` \| None       | No           | `None`      | The sequence identity threshold for weighting sequences in the MSA.                                                                                        |
-| `reference_sequence` | `string` \| None      | No           | `None`      | The reference sequence identifier in the MSA.                                                                                                              |
-| `sequence_start`     | `int` \| None         | No           | `None`      | The start position of the sequence in the MSA.                                                                                                             |
-| `sequence_end`       | `int` \| None         | No           | `None`      | The end position of the sequence in the MSA.                                                                                                               |
-| `weights`            | `list[float]` \| None | No           | `None`      | The weights for the MSA.                                                                                                                                   |
-| `weights_path`       | `string` \| None      | No           | `None`      | The path to the weights file for the MSA. Supported extensions: `.npy`.                                                                                    |
+| **Field**                 | **Type**              | **Required** | **Default** | **Description**                                                                                                                                            |
+|---------------------------|-----------------------|--------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `path`                    | `string`              | Yes          | N/A         | The path to the MSA data file or directory. In case of directories, all files within the directory will be included. Supported extensions: `.a3m`, `.msa`. |
+| `format`                  | `string`              | No           | `"fasta"`   | The format of the MSA data. Supported formats: `"fasta"`                                                                                                   |
+| `num_significant`         | `int` \| None         | No           | `None`      | The number of significant sequences to include in the MSA.                                                                                                 |
+| `bit_score`               | `float` \| None       | No           | `None`      | The bit score threshold for including sequences in the MSA.                                                                                                |
+| `theta`                   | `float` \| None       | No           | `None`      | The sequence identity threshold for weighting sequences in the MSA.                                                                                        |
+| `reference_sequence`      | `string` \| None      | No           | `None`      | The reference sequence identifier in the MSA.                                                                                                              |
+| `sequence_start`          | `int` \| None         | No           | `None`      | The start position of the sequence in the MSA.                                                                                                             |
+| `sequence_end`            | `int` \| None         | No           | `None`      | The end position of the sequence in the MSA.                                                                                                               |
+| `weights`                 | `list[float]` \| None | No           | `None`      | The weights for the MSA.                                                                                                                                   |
+| `weights_path`            | `string` \| None      | No           | `None`      | The path to the weights file for the MSA. Supported extensions: `.npy`.                                                                                    |
 | `reference_sequence_name` | `string` \| None      | No           | `None`      | The reference sequence name in the MSA.                                                                                                                    |
-| `sequence_start`         | `int` \| None         | No           | `None`      | The start position of the sequence in the MSA.                                                                                                             |
+| `sequence_start`          | `int` \| None         | No           | `None`      | The start position of the sequence in the MSA.                                                                                                             |

--- a/example_data/neime_2019.toml
+++ b/example_data/neime_2019.toml
@@ -28,10 +28,7 @@ description = "DMS score bin of the samples"
 name = "NEIME_2019"
 path = "./NEIME_2019/Assays/Assay1.csv"
 sequence_alphabet = "AA"
-
-[ assays.sequence ]
-name = "sequence"
-alias = "mutated_sequence"
+sequence_alias = "mutated_sequence"
 
 [[ assays.targets ]]
 name = "DMS Score"

--- a/notebooks/02_Creating_Manifests_and_Archives.ipynb
+++ b/notebooks/02_Creating_Manifests_and_Archives.ipynb
@@ -25,22 +25,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-10T11:52:24.134423Z",
      "start_time": "2025-12-10T11:52:24.124957Z"
     }
    },
-   "source": [
-    "# First, let's look at the example manifest\n",
-    "from pathlib import Path\n",
-    "\n",
-    "# Read the example manifest\n",
-    "manifest_path = Path(\"../example_data/neime_2019.toml\")\n",
-    "manifest_content = manifest_path.read_text(encoding=\"utf-8\")\n",
-    "\n",
-    "print(manifest_content)"
-   ],
    "outputs": [
     {
      "name": "stdout",
@@ -76,10 +67,7 @@
       "name = \"NEIME_2019\"\n",
       "path = \"./NEIME_2019/Assays/Assay1.csv\"\n",
       "sequence_alphabet = \"AA\"\n",
-      "\n",
-      "[ assays.sequence ]\n",
-      "name = \"sequence\"\n",
-      "alias = \"mutated_sequence\"\n",
+      "sequence_alias = \"mutated_sequence\"\n",
       "\n",
       "[[ assays.targets ]]\n",
       "name = \"DMS Score\"\n",
@@ -97,6 +85,7 @@
       "path = \"./NEIME_2019/sequences/A0A1I9GEU1.fasta\"\n",
       "type = \"wild_type\"\n",
       "alphabet = \"AA\"\n",
+      "uniprot_id = \"A0A1I9GEU1\"\n",
       "\n",
       "[[ structures ]]\n",
       "path = \"./NEIME_2019/Structures/computational.pdb\"\n",
@@ -115,7 +104,16 @@
      ]
     }
    ],
-   "execution_count": 1
+   "source": [
+    "# First, let's look at the example manifest\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Read the example manifest\n",
+    "manifest_path = Path(\"../example_data/neime_2019.toml\")\n",
+    "manifest_content = manifest_path.read_text(encoding=\"utf-8\")\n",
+    "\n",
+    "print(manifest_content)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -249,13 +247,13 @@
     "value = 37\n",
     "\n",
     "[[ assays ]] <br>\n",
-    "sequence = \"mutated_sequence\" <br>\n",
+    "sequence_alias = \"mutated_sequence\" <br>\n",
     "sequence_alphabet = \"AA\" <br>\n",
     "target = \"DMS_score\" <br>\n",
     "path = \"./NEIME_2019/Assays/Assay1.csv\" <br>\n",
     "\n",
     "[[ assays ]] <br>\n",
-    "sequence = \"mutated_sequence\" <br>\n",
+    "sequence_alias = \"mutated_sequence\" <br>\n",
     "sequence_alphabet = \"AA\" <br>\n",
     "target = \"DMS_score\" <br>\n",
     "path = \"./NEIME_2019/Assays/Assay2.csv\" <br>\n",
@@ -287,7 +285,7 @@
     "T = 30<br>\n",
     "\n",
     "[[ assays ]] <br>\n",
-    "sequence = \"mutated_sequence\" <br>\n",
+    "sequence_alias = \"mutated_sequence\" <br>\n",
     "sequence_alphabet = \"AA\" <br>\n",
     "target = \"DMS_score\" <br>\n",
     "path = \"./NEIME_2019/Assays/Assay2.csv\" <br>\n",
@@ -419,12 +417,14 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-10T11:54:21.157491Z",
      "start_time": "2025-12-10T11:54:21.153729Z"
     }
    },
+   "outputs": [],
    "source": [
     "complete_manifest = \"\"\"version = \"1.0.0\"\n",
     "name = \"NEIME_2019\"\n",
@@ -456,10 +456,7 @@
     "name = \"NEIME_2019\"\n",
     "path = \"./NEIME_2019/Assays/Assay1.csv\"\n",
     "sequence_alphabet = \"AA\"\n",
-    "\n",
-    "[ assays.sequence ]\n",
-    "name = \"sequence\"\n",
-    "alias = \"mutated_sequence\"\n",
+    "sequence_alias = \"mutated_sequence\"\n",
     "\n",
     "[[ assays.targets ]]\n",
     "name = \"DMS Score\"\n",
@@ -498,29 +495,17 @@
     "[ msas.metadata ]\n",
     "software = \"mmseqs2\"\n",
     "sequence_identity = \"30%\" \"\"\""
-   ],
-   "outputs": [],
-   "execution_count": 3
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-10T11:54:28.441166Z",
      "start_time": "2025-12-10T11:54:28.435799Z"
     }
    },
-   "source": [
-    "# Write the complete manifest\n",
-    "output_path = Path(\"../example_data/neime_2019_complete.toml\")\n",
-    "output_path.write_text(complete_manifest, encoding=\"utf-8\")\n",
-    "\n",
-    "print(f\"Complete manifest written to: {output_path}\")\n",
-    "\n",
-    "# Display the written content\n",
-    "print(\"\\nGenerated manifest:\")\n",
-    "print(output_path.read_text(encoding=\"utf-8\"))"
-   ],
    "outputs": [
     {
      "name": "stdout",
@@ -559,10 +544,7 @@
       "name = \"NEIME_2019\"\n",
       "path = \"./NEIME_2019/Assays/Assay1.csv\"\n",
       "sequence_alphabet = \"AA\"\n",
-      "\n",
-      "[ assays.sequence ]\n",
-      "name = \"sequence\"\n",
-      "alias = \"mutated_sequence\"\n",
+      "sequence_alias = \"mutated_sequence\"\n",
       "\n",
       "[[ assays.targets ]]\n",
       "name = \"DMS Score\"\n",
@@ -604,7 +586,17 @@
      ]
     }
    ],
-   "execution_count": 4
+   "source": [
+    "# Write the complete manifest\n",
+    "output_path = Path(\"../example_data/neime_2019_complete.toml\")\n",
+    "output_path.write_text(complete_manifest, encoding=\"utf-8\")\n",
+    "\n",
+    "print(f\"Complete manifest written to: {output_path}\")\n",
+    "\n",
+    "# Display the written content\n",
+    "print(\"\\nGenerated manifest:\")\n",
+    "print(output_path.read_text(encoding=\"utf-8\"))"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -617,27 +609,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-10T11:54:35.352818Z",
      "start_time": "2025-12-10T11:54:34.594726Z"
     }
    },
-   "source": [
-    "from proteingym.base import Manifest, Dataset\n",
-    "\n",
-    "# Load the manifest\n",
-    "manifest = Manifest.from_path(output_path)\n",
-    "\n",
-    "print(f\"Loaded manifest: {manifest.name}\")\n",
-    "print(f\"Description: {manifest.description}\")\n",
-    "print(f\"Version: {manifest.version}\")\n",
-    "print(f\"Number of assays: {len(manifest.assays)}\")\n",
-    "print(f\"Number of sequences: {len(manifest.sequences)}\")\n",
-    "print(f\"Number of structures: {len(manifest.structures)}\")\n",
-    "print(f\"Number of MSAs: {len(manifest.msas)}\")\n",
-    "print(f\"Number of assay variables: {len(manifest.assay_variables)}\")"
-   ],
    "outputs": [
     {
      "name": "stdout",
@@ -654,22 +632,38 @@
      ]
     }
    ],
-   "execution_count": 5
+   "source": [
+    "from proteingym.base import Manifest, Dataset\n",
+    "\n",
+    "# Load the manifest\n",
+    "manifest = Manifest.from_path(output_path)\n",
+    "\n",
+    "print(f\"Loaded manifest: {manifest.name}\")\n",
+    "print(f\"Description: {manifest.description}\")\n",
+    "print(f\"Version: {manifest.version}\")\n",
+    "print(f\"Number of assays: {len(manifest.assays)}\")\n",
+    "print(f\"Number of sequences: {len(manifest.sequences)}\")\n",
+    "print(f\"Number of structures: {len(manifest.structures)}\")\n",
+    "print(f\"Number of MSAs: {len(manifest.msas)}\")\n",
+    "print(f\"Number of assay variables: {len(manifest.assay_variables)}\")"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "Note that while we only passed the doi on the publication, remaining details such as title and authors get populated automatically when we request the those properties."
+   "metadata": {},
+   "source": [
+    "Note that while we only passed the doi on the publication, remaining details such as title and authors get populated automatically when we request the those properties."
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-12-10T11:54:46.288650Z",
      "start_time": "2025-12-10T11:54:45.609477Z"
     }
    },
-   "cell_type": "code",
-   "source": "manifest.publication",
    "outputs": [
     {
      "data": {
@@ -687,12 +681,14 @@
        ")"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 6
+   "source": [
+    "manifest.publication"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -705,7 +701,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -749,7 +745,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -757,7 +753,7 @@
      "output_type": "stream",
      "text": [
       "Dataset archived to: ../example_data/NEIME_2019.pgdata\n",
-      "Archive size: 1302.8 KB\n"
+      "Archive size: 1303.3 KB\n"
      ]
     }
    ],
@@ -779,7 +775,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -787,8 +783,8 @@
      "output_type": "stream",
      "text": [
       "Archive contents:\n",
-      "  manifest.lock (1150 bytes)\n",
-      "  assays/Assay1.csv (158316 bytes)\n",
+      "  manifest.lock (1727 bytes)\n",
+      "  assays/NEIME_2019.csv (158308 bytes)\n",
       "  sequences/tr|A0A1I9GEU1|A0A1I9GEU1_NEIME.fasta (245 bytes)\n",
       "  structures/A0A1I9GEU1.pdb (97127 bytes)\n",
       "  msas/A0A1I9GEU1_NEIME.fasta (1076529 bytes)\n"
@@ -890,10 +886,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
    "outputs": [],
-   "execution_count": null,
    "source": [
     "from proteingym.base import Manifest\n",
     "from proteingym.base.assay import AssayManifestSection, Field\n",
@@ -910,10 +906,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
    "outputs": [],
-   "execution_count": null,
    "source": [
     "assay_variables = [\n",
     "    Field(name=\"T\", description=\"Reaction temperature\", unit=\"°C\", value=\"37\"),\n",
@@ -922,10 +918,10 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
    "outputs": [],
-   "execution_count": null,
    "source": [
     "assay_targets = [\n",
     "    Field(\n",
@@ -946,14 +942,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
     "assays = [\n",
     "    AssayManifestSection(\n",
     "        name=\"NEIME_2019\",\n",
-    "        sequence=Field(name=\"mutated_sequence\"),\n",
+    "        sequence_alias=\"mutated_sequence\",\n",
     "        targets=[Field(name=\"DMS Score\", alias=\"DMS_score\"), Field(name=\"DMS Score Bin\", alias=\"DMS_score_bin\")],\n",
     "        sequence_alphabet=\"AA\",\n",
     "        path=Path(\"../example_data/NEIME_2019/Assays/Assay1.csv\"),\n",
@@ -977,7 +973,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -999,7 +995,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1019,11 +1015,11 @@
    ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "outputs": [],
    "execution_count": null,
-   "source": ""
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -1034,7 +1030,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1058,7 +1054,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1077,7 +1073,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -1086,7 +1082,7 @@
        "PosixPath('../example_data/neime_2019_python_example.toml')"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1105,7 +1101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -1141,7 +1137,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pg2-dataset",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1155,7 +1151,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/src/proteingym/base/assay.py
+++ b/src/proteingym/base/assay.py
@@ -24,6 +24,7 @@ from pydantic import (
 
 from .sequence import Sequence, SequenceAlphabet, SequenceType
 
+SEQUENCE = "sequence"
 RECORDS = list[tuple[Sequence | str | int | float | bool | str | None, ...]]
 
 
@@ -231,7 +232,7 @@ class AssayManifestSection(_ManifestSection):
     )
     """Configuration for the Pydantic model."""
 
-    sequence: Field = pydantic.Field(default_factory=lambda: Field(name="sequence"))
+    sequence_alias: str | None = None
     """The sequence feature name given in the file."""
 
     sequence_alphabet: SequenceAlphabet | None = None
@@ -252,10 +253,11 @@ class AssayManifestSection(_ManifestSection):
     @model_validator(mode="after")
     def validate_fields(self) -> "AssayManifestSection":
         """Validate whether field names are present in the `path` file."""
-        for v in [self.sequence] + self.targets:
+        sequence = Field(name="sequence", alias=self.sequence_alias)
+        for v in [sequence] + self.targets:
             if v.alias_ not in self._header:
                 raise ValueError(
-                    f"Feature '{v.name}' not found in the file: {self.path}"
+                    f"Feature '{v.alias_}' not found in the file: {self.path}"
                 )
         return self
 
@@ -313,7 +315,7 @@ class AssayRaw:
     """A brief description"""
 
     fields: list[Field] = dataclasses.field(
-        default_factory=lambda: [Field(name="sequence")]
+        default_factory=lambda: [Field(name=SEQUENCE)]
     )
     """The raw assay fields."""
 
@@ -590,16 +592,14 @@ class Assay(AssayRaw):
     @classmethod
     def from_manifest_section(cls, section: AssayManifestSection) -> "Assay":
         """Create an Assay instance from a manifest section."""
-
-        df = pl.read_csv(
-            section.path,
-            columns=[section.sequence.alias_] + [f.alias_ for f in section.targets],
-        )
+        sequence_field = Field(name=SEQUENCE, alias=section.sequence_alias)
+        all_fields = [sequence_field] + section.targets
+        df = pl.read_csv(section.path, columns=[f.alias_ for f in all_fields])
         df = df.with_columns(
             # Sequences are created from sequence strings present in the file
             # The sequence name is taken from the string itself as the name is not
             # provided in the assay file.
-            pl.col(section.sequence.alias_)
+            pl.col(sequence_field.alias_)
             .map_elements(
                 lambda seq: Sequence(
                     # The type of the sequence is set to "standard". This would be
@@ -622,7 +622,7 @@ class Assay(AssayRaw):
         return cls(
             name=section.name or section.path.stem,
             records=records,
-            fields=[section.sequence] + section.targets,
+            fields=all_fields,
             description=section.description,
             variables=section.variables,
         )
@@ -645,7 +645,7 @@ class Assay(AssayRaw):
         return AssayManifestSection(
             name=self.name,
             description=self.description,
-            sequence=self.fields[0].without_alias(),
+            sequence_alias=None,
             sequence_alphabet=sequence_alphabet,
             targets=[f.without_alias() for f in self.fields[1:]],
             variables=self.variables,
@@ -666,7 +666,7 @@ class Assay(AssayRaw):
         """
         if self.is_empty():
             # If no records are present, return empty DataFrame
-            return pl.DataFrame(schema=["sequence"])
+            return pl.DataFrame(schema=[SEQUENCE])
         if target_names:
             if isinstance(target_names, str):
                 target_names = {target_names}
@@ -674,7 +674,7 @@ class Assay(AssayRaw):
                 target_names = set(target_names).intersection(self.target_feature_names)
             if not target_names:
                 # If not matching target names, return empty DataFrame
-                return pl.DataFrame(schema=["sequence"])
+                return pl.DataFrame(schema=[SEQUENCE])
         else:
             target_names = self.target_feature_names
 
@@ -692,7 +692,7 @@ class Assay(AssayRaw):
                     lambda seq: str(seq.value), return_dtype=pl.Utf8
                 )
             )
-            .rename({self.sequence_feature_name: "sequence"})
+            .rename({self.sequence_feature_name: SEQUENCE})
             .with_columns(variables)
         )
 

--- a/src/proteingym/base/dataset.py
+++ b/src/proteingym/base/dataset.py
@@ -14,7 +14,7 @@ import pydantic
 from Bio.Seq import Seq
 from pydantic import BaseModel, ConfigDict, model_validator
 
-from .assay import Assay, AssayRaw, AssaySlice, Field
+from .assay import SEQUENCE, Assay, AssayRaw, AssaySlice, Field
 from .manifest import MANIFEST_LATEST_VERSION, Manifest
 from .msa import MSA
 from .publication import Publication
@@ -771,7 +771,7 @@ class Dataset(BaseModel):
             df = df.with_columns(missing_variables)
 
             assays_dfs.append(
-                df.select(["sequence"] + variable_names + list(target_names))
+                df.select([SEQUENCE] + variable_names + list(target_names))
             )
 
         df = pl.concat(assays_dfs, how="vertical_relaxed").filter(
@@ -779,7 +779,7 @@ class Dataset(BaseModel):
         )
 
         # If no duplication no need for aggregation
-        group_cols = ["sequence"] + variable_names
+        group_cols = [SEQUENCE] + variable_names
         duplicate_count = df.group_by(group_cols).len().filter(pl.col("len") > 1).height
         if duplicate_count == 0:
             return df.sort(group_cols)
@@ -836,7 +836,7 @@ class Dataset(BaseModel):
 def dummy_dataset() -> Dataset:
     """Create a trivial dataset for illustrative purposes."""
     fields = [
-        Field(name="sequence", description=""),
+        Field(name=SEQUENCE, description=""),
         Field(name="numerical", description=""),
         Field(name="categorical", description=""),
     ]

--- a/src/proteingym/base/transformers.py
+++ b/src/proteingym/base/transformers.py
@@ -13,7 +13,7 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import OneHotEncoder, StandardScaler
 
-from .assay import FieldEncoding
+from .assay import SEQUENCE, FieldEncoding
 from .dataset import Dataset
 
 
@@ -49,7 +49,7 @@ class SequenceOneHotEncoder(BaseEstimator, TransformerMixin):
             ValueError: If sequences have varying lengths.
         """
         if isinstance(X, Dataset):
-            X = X.to_df()["sequence"]
+            X = X.to_df()[SEQUENCE]
 
         # Flatten to 1D array
         sequences = X.to_numpy().ravel()
@@ -113,7 +113,7 @@ class SequenceOneHotEncoder(BaseEstimator, TransformerMixin):
                 length from fitting.
         """
         if isinstance(X, Dataset):
-            X = X.to_df()["sequence"]
+            X = X.to_df()[SEQUENCE]
 
         # Flatten to 1D array
         sequences = X.to_numpy().ravel()
@@ -222,7 +222,7 @@ class AssayTransformer(BaseEstimator, TransformerMixin):
 
     def __init__(
         self,
-        sequence_column: str = "sequence",
+        sequence_column: str = SEQUENCE,
         target_columns: list[str] | None = None,
         categorical_columns: list[str] | None = None,
         numerical_columns: list[str] | None = None,
@@ -271,7 +271,7 @@ class AssayTransformer(BaseEstimator, TransformerMixin):
                     raise ValueError(f"Undefined encoding for {var.name}")
 
         return cls(
-            sequence_column="sequence",
+            sequence_column=SEQUENCE,
             target_columns=target_columns,
             categorical_columns=categorical_variables,
             numerical_columns=numerical_variables,

--- a/tests/test_assay.py
+++ b/tests/test_assay.py
@@ -309,7 +309,7 @@ def test_assay_manifest_section(assay_file: Path) -> None:
         section = AssayManifestSection(
             name="test_assay",
             description="Test assay",
-            sequence=Field(name="sequence"),
+            sequence_alias="sequence",
             sequence_alphabet=SequenceAlphabet.AA,
             targets=[
                 Field(name="DMS Score", alias="target"),
@@ -325,7 +325,7 @@ def test_assay_manifest_section(assay_file: Path) -> None:
         assert isinstance(section.path, Path)
         with assay_file.open() as f:
             content = f.read()
-        assert section.sequence.alias_ in content
+        assert section.sequence_alias in content
         assert all(target.alias_ in content for target in section.targets)
 
 
@@ -350,7 +350,6 @@ def test_assay_manifest_section_validate_feature_names(assay_file: Path) -> None
         AssayManifestSection(
             name="test_assay",
             description="Test assay",
-            sequence=Field(name="invalid_feature"),
             sequence_alphabet=SequenceAlphabet.AA,  # noqa
             targets=[Field(name="DMS Score", alias="invalid_feature")],
             variables={"test_cond1": "true", "test_cond2": 42},
@@ -553,7 +552,6 @@ def test_assay_from_manifest_section(assay_file: Path) -> None:
         assay = Assay.from_manifest_section(
             AssayManifestSection(
                 name="assay",
-                sequence=Field(name="sequence"),
                 sequence_alphabet=SequenceAlphabet.DNA,
                 targets=[
                     Field(name="DMS Score", alias="target"),

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -36,9 +36,6 @@ name = "assay"
 path = "assay.csv"
 sequence_alphabet = "AA"
 
-[ assays.sequence ]
-name = "sequence"
-
 [[ assays.targets ]]
 name = "DMS Score"
 alias = "DMS_score"


### PR DESCRIPTION
# Introduce sequence-alias instead of whole field in manifest

while we store the sequence as a field to make it symmetric with other field, it's not handy to enable user provide the whole field definition since type etc are not meaningful to change.



Resolves #425 

# Checklist

- [ ] I broke the PR down so that it contains a reasonable amount of changes for an effective review
- [x] I performed a self-review of my code. Amongst other things, I have commented my code in hard-to-understand areas.
- [x] I made corresponding changes to the documentation
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I accounted for dependent changes to be merged and published in downstream modules
