### PR TITLE
Updated splitting ipynb and changed tutorials for splitting

### DIFF
--- a/docs/notebooks/05_Creating_Dataset_Splits.ipynb
+++ b/docs/notebooks/05_Creating_Dataset_Splits.ipynb
@@ -96,6 +96,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Subsets: a dataset of dataset slices\n",
+    "\n",
+    "So far we only have concerned ourselves with the `Dataset` class in the tutorials, but when we are talking about the splits we introduce a new class, the `Subset`. \n",
+    "\n",
+    "In mathematical terms, a set A (e.g. training split) is a subset of set B (e.g. the original dataset) if all elements of A are also elements of B. B is then considered the superset of A. We keep a similar relation in proteingym datasets.\n",
+    "\n",
+    "In proteingym we store the collection of the split information as Subsets, a dataset of dataset slices. We only group subsets together and do not allow for the creation of a subset of different supersets (e.g. grouping multiple different datasets in one subset).\n",
+    "\n",
+    "Thus to work with the split data, we load `Subsets`, and not `Datasets`. How we load and use `Subsets` is explained in the tutorial below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Loading the Dataset\n",
     "\n",
     "Let's start by loading our example dataset:"
@@ -140,8 +155,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In ProteinGym we always perform splitting in a two step approach. In the first step we initialize the split with the specific settings for the split, while in the second step we split the specific dataset. \n",
-    "\n",
+    "Since we are using a `Subset` to indicate the splits, we need to create a `Subset` from our `Dataset` to hold the splitting information. Then we can perform the splitting in a two step approach. In the first step we initialize the split with the specific split settings, while in the second step we update our Subset with the dataset slices."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "For example:"
    ]
   },
@@ -149,11 +169,39 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "from proteingym.base import Subsets\n",
+    "\n",
+    "# Let's load the dataset into a subset\n",
+    "subsets = Subsets(dataset=dataset)\n",
+    "\n",
+    "# Let's define a splitter (we'll explain more details about this splitter further in the tutorial)\n",
+    "my_split_class = RandomSplitter(fractions=[0.8, 0.1, 0.1]) #80% train, 10% validation, 10% test\n",
+    "\n",
+    "# But we can also update our original subsets:\n",
+    "subsets.update(random=my_split_class.split(dataset=dataset))\n",
+    "\n",
+    "# You can assign the split to any abritary name, e.g.:\n",
+    "subsets.update(my_arbitrary_name=my_split_class.split(dataset=dataset))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we take a look at the contents of `subsets`, we see that the subsets contain a dataset,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Subsets(dataset=Dataset(\n",
+       "Dataset(\n",
        "\tname='NEIME_2019',\n",
        "\tdescription: The NEIME Kennouche 2019 (UniProt id: A0A1I9GEU1) datase,\n",
        "\tcontents:\n",
@@ -174,19 +222,55 @@
        "\tpages: None, \n",
        "\tdoi: 10.15252/embj.2019102145, \n",
        "),\n",
-       "), slices=[DatasetSlice(assays=[AssaySlice(columns=None, records=[True, True, True, False, True, True, True, True, True, True, True, False, True, True, True, False, False, True, True, True, True, True, False, True, True, True, True, True, True, False, True, True, False, True, True, False, True, False, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, False, True, True, True, True, True, True, True, True, True, True, False, True, True, False, True, True, True, True, True, True, False, False, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, False, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, False, True, True, True, False, False, False, True, True, True, False, True, True, True, False, True, False, True, True, False, True, False, True, True, True, True, True, True, False, True, True, True, True, True, False, True, False, True, True, True, True, True, True, True, False, False, True, True, True, False, True, True, True, True, True, True, False, True, True, False, True, True, True, True, True, False, True, True, False, True, True, True, True, True, True, True, True, False, True, False, True, True, False, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, False, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, False, True, False, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, False, True, False, True, False, True, True, True, False, False, False, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, False, True, True, True, False, True, True, True, True, True, False, True, False, True, True, True, True, True, True, False, True, True, True, False, True, True, True, True, True, True, True, True, True, False, False, True, True, True, True, True, True, True, True, False, True, True, True, False, True, False, True, True, True, True, False, True, False, True, True, False, False, False, True, False, False, True, False, True, False, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, False, True, False, False, True, True, True, True, True, True, True, True, True, True, True, True, False, False, True, True, False, False, True, True, False, False, True, True, True, True, False, True, True, True, True, False, True, True, True, True, True, True, True, True, True, False, True, True, True, False, True, True, True, True, True, True, True, True, True, True, False, True, True, True, False, True, True, True, True, True, True, False, True, True, True, True, True, False, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, False, True, False, True, True, True, False, False, True, False, False, True, False, False, False, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, False, True, False, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, False, True, True, False, True, True, True, True, True, True, False, False, True, True, True, True, True, True, True, True, True, False, True, True, True, False, False, True, True, True, True, True, True, False, False, True, True, True, True, True, True, True, False, True, True, True, True, True, True, False, True, True, True, False, True, True, False, True, True, True, True, True, True, True, False, True, False, True, False, False, True, True, True, True, False, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, False, True, True, True, True, True, True, False, False, True, False, True, True, True, True, True, True, True, False, True, False, True, True, True, True, True, True, True, False, True, False, True, True, True, False, True, False, True, True, False, True, True, True, True, True, True, False, False, True, True, True, True, True, False, True, False, True, True, True, True, True, False, True, True, True, False, False, True, True, True, True, False, True, True, True, True, False, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, False, False, True, True, True, True, False, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, False, True, True, True, True, True, False, False, True, True, True, False, True, True, True, True, True, True, True, False, False, True, True, False, True, True, True, True, True, True, False, True, False, False, False, True, True, True, True, False, True, True, True, True, False, True, True, False, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, False, True, True, True, False, False, True, False, True, True, True, True, True, True, False, True, True, True, False, False, True, True, True, True, True, True, True])]), DatasetSlice(assays=[AssaySlice(columns=None, records=[False, False, False, True, False, False, False, False, False, False, False, True, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, True, False, True, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, True, False, True, False, False, False, True, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, True, True, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, True, False, False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, True, False, False, False, True, False, True, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, True, True, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, True, False, True, False, False, False, True, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, True, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, True, False, False, True, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, True, False, False, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, False, True, False, False, False, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, True, False, True, True, True, False, False, False, False, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False])]), DatasetSlice(assays=[AssaySlice(columns=None, records=[False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, True, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, True, False, False, False, False, False, False, False, False, True, False, True, False, False, True, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, True, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, True, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, False, True, False, True, False, True, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, True, False, False, False, True, False, False, False, False, True, False, False, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, True, False, True, True, True, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, True, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, True, False, False, True, False, False, False, False, True, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, True, False, True, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, True, False, False, True, False, False, False, False, False, False, True, True, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, True, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, True, True, False, False, False, False, False, False, False])])])"
+       ")"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "my_split_class = RandomSplitter(fractions=[0.8, 0.1, 0.1]) #80% train, 10% validation, 10% test\n",
-    "subsets = my_split_class.split(dataset=dataset)\n",
-    "\n",
-    "subsets"
+    "subsets.dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and that the subset also contains the slices:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'random': [DatasetSlice(assays=[AssaySlice(columns=None, records=[True, True, True, True, True, True, False, True, True, True, True, True, True, False, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, False, True, False, True, True, True, True, False, True, True, True, True, False, True, True, True, False, True, False, True, True, False, True, True, False, False, True, False, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, False, True, True, False, False, True, True, True, True, False, True, True, False, True, False, True, True, True, True, True, False, True, False, True, False, True, True, True, True, True, True, True, False, True, True, True, True, True, True, False, True, True, False, True, True, True, False, True, True, True, False, False, True, False, False, True, True, False, True, True, True, False, True, True, False, True, True, True, True, False, True, False, True, True, True, False, True, False, True, True, True, True, True, True, False, True, True, True, True, True, False, True, False, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, False, True, True, False, True, False, False, True, True, True, True, False, True, False, True, True, True, True, True, True, True, False, True, False, False, False, True, True, True, True, True, False, True, True, True, False, True, False, True, False, False, True, True, True, True, True, False, True, True, True, True, True, True, True, False, True, True, False, True, True, False, True, True, True, True, True, False, True, False, True, True, False, True, True, True, True, False, True, True, True, False, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, False, True, True, False, True, True, False, True, True, True, False, True, True, True, True, False, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, False, True, True, True, False, True, True, True, True, False, True, True, False, True, True, False, True, True, False, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, False, True, True, True, False, True, True, True, True, False, True, True, True, True, True, True, True, False, True, True, True, False, True, True, False, True, False, True, True, True, True, True, False, True, False, True, True, True, False, True, False, False, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, False, False, True, True, True, True, True, True, True, True, True, False, False, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, False, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, False, True, True, False, True, True, True, True, False, True, False, True, True, True, True, False, True, True, False, True, False, True, True, True, True, True, True, False, False, False, True, False, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, False, True, True, False, False, True, True, True, True, True, False, True, True, True, True, True, False, False, True, True, True, True, True, True, True, True, True, False, True, False, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, False, True, False, True, True, True, True, False, True, True, True, True, False, True, True, True, True, True, True, True, True, False, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, False, True, True, True, True, True, False, True, True, False, True, True, False, False, True, False, True, True, True, True, True, True, True, True, False, False, False, True, False, True, False, True, True, True, True, True, True, True, True, True, True, False, True, True, False, False, True, True, False, True, False, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, False, True, True, False, True, True, False, True, True, True, False, False, True, True, True, True, True, True, False, False, True, False, True, True, False, True, True, True, True, True, False, True, False, True, True, True, False, True, False, True, False, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, False, True, True, False, True, False, False, True, True, True, True, True, True, True, False, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, False, True, True, False, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, False, True, True, True, True, False, True, True, True, True, True, True, True, True, True])]),\n",
+       "  DatasetSlice(assays=[AssaySlice(columns=None, records=[False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, True, False, True, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, True, False, False, False, False, True, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, True, True, False, True, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, True, False, True, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, True, False, False, True, False, False, False, False, True, False, True, False, False, False, False, False, False, False, False, False, True, False, True, False, False, False, False, False, False, False, False, False, False, False, True, False, True, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, True, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, True, False, False, False, True, False, False, False, False, True, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, True, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, True, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, True, False, True, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, True, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, True, False, False, False, True, True, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False])]),\n",
+       "  DatasetSlice(assays=[AssaySlice(columns=None, records=[False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, True, False, False, False, False, True, False, False, False, False, True, False, False, False, True, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, True, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, False, True, False, False, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, True, False, False, False, True, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, False, False, True, False, True, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, True, False, False, False, True, False, False, False, False, False, False, False, False, False, False, True, False, True, False, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, True, True, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, True, False, False, False, False, True, False, False, False, False, True, False, False, False, False, False, False, True, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, True, False, False, True, False, False, False, False, False, False, True, False, False, False, False, False, True, True, False, False, False, False, False, False, False, False, False, True, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, True, True, False, True, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, True, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, True, False, False, True, False, False, False, False, False, True, False, False, False, False, False, True, False, True, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, True, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False])])],\n",
+       " 'my_arbitrary_name': [DatasetSlice(assays=[AssaySlice(columns=None, records=[True, False, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, False, True, True, True, True, True, True, True, False, True, True, False, False, False, False, False, False, True, True, True, True, True, True, True, True, True, False, True, False, True, True, False, True, True, True, True, True, True, True, False, False, True, True, True, False, True, True, True, False, True, True, True, True, False, True, True, True, True, True, True, True, False, True, True, True, False, True, True, True, True, False, True, True, True, True, True, False, True, True, False, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, False, True, True, False, True, True, False, True, True, True, True, True, False, True, True, False, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, False, False, True, False, True, True, False, False, False, False, True, True, True, True, True, True, True, True, False, True, False, True, True, False, True, True, True, True, False, True, True, True, True, True, True, True, True, False, True, True, False, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, False, True, False, True, True, True, False, True, True, False, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, False, True, True, True, False, True, False, True, False, True, True, True, True, True, False, True, True, False, False, False, True, True, True, False, True, False, True, True, True, False, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, False, True, True, True, False, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, False, True, False, True, True, True, True, True, False, True, False, True, True, True, False, True, True, True, False, True, False, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, False, True, True, True, True, True, False, False, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, False, True, False, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, False, True, True, True, True, True, True, False, True, True, True, False, True, True, True, False, True, True, True, False, True, False, False, True, False, True, True, False, False, False, True, True, True, True, True, False, True, False, True, True, True, True, True, True, True, True, False, True, True, True, True, True, False, True, True, True, True, False, True, False, False, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, False, True, True, False, True, True, True, True, True, True, True, True, True, False, True, True, True, False, False, False, True, True, True, True, True, True, False, True, False, True, True, False, True, True, False, True, True, False, True, True, True, True, False, True, True, True, False, True, False, True, False, True, True, True, False, True, True, True, True, True, False, True, True, True, True, False, True, True, True, True, False, False, True, True, True, True, False, False, True, True, True, True, True, True, False, False, True, False, True, True, False, True, False, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, False, False, True, True, False, True, False, False, True, False, True, True, False, True, True, False, True, True, True, True, True, False, False, True, True, True, False, True, True, True, False, True, True, True, False, True, True, True, True, False, False, False, True, False, False, True, False, True, True, True, True, False, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, False, True, True, False, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, True, False, False, True, True, True, True, False, True, True, True, True, True, True, True, False, True, True, True, True, True, True, True, False, True, True, True, True, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, True, True, True, False, True, True, True, True, True, True, True, True, True, False, True, True, False, True, True, False, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, False, True, False, False, True, False, True, False, True, False, True, False, True, True, True])]),\n",
+       "  DatasetSlice(assays=[AssaySlice(columns=None, records=[False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, True, False, True, True, False, False, False, False, False, False, False, False, False, False, False, True, False, True, False, False, True, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, True, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, True, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, True, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, True, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, True, False, False, False, True, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, False, True, True, False, False, False, False, False, False, True, False, True, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, False, True, False, True, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, True, False, False, False, True, False, True, False, True, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, True, False, False, False, False, False, False, True, True, False, False, False, False, True, False, True, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, False, False, False, False, False, True, True, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, True, False, False, False, True, True, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, True, False, False, True, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, True, False, False, False, True, False, False, False])]),\n",
+       "  DatasetSlice(assays=[AssaySlice(columns=None, records=[False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, True, False, False, False, False, False, False, False, False, False, False, False, True, False, False, True, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, True, False, False, True, True, True, False, False, False, False, False, False, False, False, False, True, False, True, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, True, False, False, False, False, False, True, False, False, True, True, False, False, False, False, True, False, True, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, True, False, False, False, False, False, False, False, True, False, True, False, False, True, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, True, True, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, True, False, True, False, False, False, False, False, True, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, True, False, False, True, False, False, False, False, True, False, False, True, False, False, False, False, False, False, False, False, False, False, True, False, False, False, True, False, False, False, False, False, False, False, False, False, True, True, False, False, False, False, True, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, True, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, True, False, False, True, False, True, False, False, False, True, False, False, False, False, False])])]}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "subsets.slices"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see that the slices are stored as a dictionary, where the name of the key is the splitting method. E.g. here we see the `random split`, and the `my_arbitrary_name` split from the example above. "
    ]
   },
   {
@@ -198,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,8 +290,9 @@
     "my_list_of_datasets = [dataset, dataset] #duplication of the NEIME dataset for illustrative purposes\n",
     "\n",
     "for dataset in my_list_of_datasets:\n",
-    "    split_dataset = randomsplit.split(dataset=dataset)\n",
-    "    split_dataset.dump() # NOTE: This will create one .splits.pgdata file as its overwritten by the duplicate dataset"
+    "    subsets = Subsets(dataset=dataset)\n",
+    "    subsets.update(random=randomsplit.split(dataset=dataset))\n",
+    "    subsets.dump() # NOTE: This will create one .splits.pgdata file as its overwritten by the duplicate dataset"
    ]
   },
   {
@@ -221,73 +306,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Random Splits\n",
-    "\n",
-    "Random splits divide your data into training, validation, and test sets with specified proportions. The `RandomSplitter` can be made deterministic by passing a random seed."
+    "### Multiple splits per dataset"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Three-way Split (Train/Validation/Test)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Split proportions: [0.8, 0.1, 0.1]\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Create a 80/10/10 train/validation/test split\n",
-    "random_splitter = RandomSplitter(fractions=[0.8, 0.1, 0.1], random_state=42)\n",
-    "\n",
-    "print(f\"Split proportions: {random_splitter.fractions}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Created 3 splits:\n",
-      "  Train: 738 samples (80.0%)\n",
-      "  Validation: 92 samples (10.0%)\n",
-      "  Test: 92 samples (10.0%)\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Generate the split\n",
-    "split_superset = random_splitter.split(dataset=dataset)\n",
-    "\n",
-    "print(f\"Created {len(split_superset)} splits:\")\n",
-    "split_names = [\"Train\", \"Validation\", \"Test\"]\n",
-    "\n",
-    "for i, split_dataset in enumerate(split_superset):\n",
-    "    count = len(split_dataset.assays[0].records)\n",
-    "    total = len(dataset.assays[0].records)\n",
-    "    percentage = (count / total) * 100\n",
-    "    print(f\"  {split_names[i]}: {count} samples ({percentage:.1f}%)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### You can do any N-way split"
+    "To facilitate different split types for your dataset, you can add more than one set of slices. As long as the name for the set of slices is unique, so e.g.:"
    ]
   },
   {
@@ -299,28 +325,45 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Split: 369 samples\n",
-      "Split: 277 samples\n",
-      "Split: 184 samples\n",
-      "Split: 92 samples\n"
+      "Split: classic: 738 samples\n",
+      "Split: classic: 92 samples\n",
+      "Split: classic: 92 samples\n",
+      "Split: kfold: 184 samples\n",
+      "Split: kfold: 184 samples\n",
+      "Split: kfold: 184 samples\n",
+      "Split: kfold: 184 samples\n",
+      "Split: kfold: 186 samples\n"
      ]
     }
    ],
    "source": [
-    "n_way_split = RandomSplitter(fractions=[0.4, 0.3, 0.2, 0.1])\n",
-    "n_way_superset = n_way_split.split(dataset)\n",
+    "subsets = Subsets(dataset=dataset)\n",
     "\n",
-    "for split_dataset in n_way_superset:\n",
-    "    print(f\"Split: {len(split_dataset.assays[0].records)} samples\")"
+    "random_classic = RandomSplitter(fractions=[0.8, 0.1, 0.1])\n",
+    "random_kfold = RandomSplitter(fractions=[0.2, 0.2, 0.2, 0.2, 0.2])\n",
+    "\n",
+    "subsets.update(classic=random_classic.split(dataset=dataset))\n",
+    "subsets.update(kfold=random_kfold.split(dataset=dataset))\n",
+    "\n",
+    "for split in subsets.slices.keys():\n",
+    "    for subset in subsets[split]:\n",
+    "        print(f\"Split: {split}: {len(subset.assays[0].records)} samples\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## K-Fold Cross-Validation Splits\n",
+    "## Splitting methods"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Random Splits\n",
     "\n",
-    "K-fold splits divide data into k equal-sized folds for cross-validation. Each fold can serve as a test set while the remaining folds form the training set."
+    "Random splits divide your data into training, validation, and test sets with specified proportions. The `RandomSplitter` can be made deterministic by passing a random seed."
    ]
   },
   {
@@ -332,19 +375,36 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "K-fold configuration:\n",
-      "  Number of folds: 5\n",
-      "  Shuffle data: True\n"
+      "Created 2 splits:\n",
+      "  Train: 738 samples (80.0%)\n",
+      "  Validation: 184 samples (20.0%)\n"
      ]
     }
    ],
    "source": [
-    "# Create 5-fold cross-validation splits\n",
-    "kfold_splitter = KFoldSplitter(n_splits=5, shuffle=True)\n",
+    "subsets = Subsets(dataset=dataset)\n",
     "\n",
-    "print(f\"K-fold configuration:\")\n",
-    "print(f\"  Number of folds: {kfold_splitter.n_splits}\")\n",
-    "print(f\"  Shuffle data: {kfold_splitter.shuffle}\")"
+    "# Create a 80/20 train/test split\n",
+    "random_splitter = RandomSplitter(fractions=[0.8, 0.2], random_state=42)\n",
+    "subsets.update(random=random_splitter.split(dataset=dataset)) \n",
+    "\n",
+    "print(f\"Created {len(subsets.slices['random'])} splits:\")\n",
+    "split_names = [\"Train\", \"Validation\", \"Test\"]\n",
+    "\n",
+    "for enum, split in enumerate(subsets['random']):\n",
+    "    count = len(split.assays[0].records)\n",
+    "    total = len(dataset.assays[0].records)\n",
+    "    percentage = (count / total) * 100\n",
+    "    print(f\"  {split_names[enum]}: {count} samples ({percentage:.1f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### K-Fold splits\n",
+    "\n",
+    "K-fold splits divide data into k equal-sized folds for cross-validation. Each fold can serve as a test set while the remaining folds form the training set."
    ]
   },
   {
@@ -356,6 +416,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "K-fold configuration:\n",
+      "  Number of folds: 5\n",
+      "  Shuffle data: True\n",
       "\n",
       "Created 5 folds:\n",
       "  Fold 1: 737 train, 185 test samples\n",
@@ -367,13 +430,20 @@
     }
    ],
    "source": [
-    "# Generate the k-fold splits\n",
-    "kfold_superset = kfold_splitter.split(dataset=dataset)\n",
+    "subsets = Subsets(dataset=dataset)\n",
     "\n",
-    "print(f\"\\nCreated {len(kfold_superset)} folds:\")\n",
+    "# Create 5-fold cross-validation splits\n",
+    "kfold_splitter = KFoldSplitter(n_splits=5, shuffle=True)\n",
+    "subsets.update(kfold=kfold_splitter.split(dataset=dataset))\n",
+    "\n",
+    "print(f\"K-fold configuration:\")\n",
+    "print(f\"  Number of folds: {kfold_splitter.n_splits}\")\n",
+    "print(f\"  Shuffle data: {kfold_splitter.shuffle}\")\n",
+    "\n",
+    "print(f\"\\nCreated {len(subsets['kfold'])} folds:\")\n",
     "total_samples = len(dataset.assays[0].records)\n",
     "\n",
-    "for i, fold_dataset in enumerate(kfold_superset):\n",
+    "for i, fold_dataset in enumerate(subsets['kfold']):\n",
     "    test_count = len(fold_dataset.assays[0].records)\n",
     "    train_count = total_samples - test_count\n",
     "    print(f\"  Fold {i+1}: {train_count} train, {test_count} test samples\")"
@@ -407,8 +477,11 @@
     }
    ],
    "source": [
+    "random_classic = RandomSplitter(fractions=[0.8, 0.1, 0.1])\n",
+    "single_subset = random_classic.split(dataset=dataset)\n",
+    "\n",
     "# Unpack the three-way split\n",
-    "train_dataset, val_dataset, test_dataset = tuple(split_superset)\n",
+    "train_dataset, val_dataset, test_dataset = tuple(single_subset)\n",
     "\n",
     "print(f\"Training dataset: {len(train_dataset.assays[0].records)} samples\")\n",
     "print(f\"Validation dataset: {len(val_dataset.assays[0].records)} samples\")\n",
@@ -460,12 +533,14 @@
    "source": [
     "from proteingym.base.splits import PredefinedSplitter\n",
     "\n",
+    "subsets = Subsets(dataset=dataset)\n",
+    "\n",
     "predefined = PredefinedSplitter(\n",
     "    split_column=\"split\", # The aliased name of the column in your assay\n",
     "    split_order=[\"train\", \"valid\", \"test\"] # The ordering of the returned datasets\n",
     ")\n",
     "\n",
-    "my_splits = predefined.split(dataset=dataset)"
+    "subsets.update(predefined=predefined.split(dataset=dataset))"
    ]
   },
   {
@@ -491,7 +566,7 @@
     }
    ],
    "source": [
-    "for dataset in my_splits:\n",
+    "for dataset in subsets['predefined']:\n",
     "    print(dataset.assays[0].records[0][3])"
    ]
   },
@@ -533,7 +608,7 @@
    ],
    "source": [
     "# Archive the random split\n",
-    "archive_path = split_superset.dump(path=Path(\"../example_data/\"))\n",
+    "archive_path = subsets.dump(path=Path(\"../example_data/\"))\n",
     "print(f\"Split archived to: {archive_path}\")\n",
     "print(f\"Archive size: {archive_path.stat().st_size / 1024:.1f} KB\")"
    ]
@@ -543,6 +618,13 @@
    "metadata": {},
    "source": [
     "### Loading Archived Splits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To load an archived subset (split dataset), you can use the `.from_path(/path/to/file)` method:"
    ]
   },
   {
@@ -569,12 +651,12 @@
     "loaded_splits = Subsets.from_path(archive_path)\n",
     "\n",
     "print(f\"Loaded splits from archive\")\n",
-    "print(f\"Number of splits: {len(loaded_splits)}\")\n",
+    "print(f\"Number of splits: {len(loaded_splits['predefined'])}\")\n",
     "print(f\"Original dataset name: {loaded_splits.dataset.name}\")\n",
     "\n",
-    "# Verify the splits are identical\n",
-    "original_train = tuple(split_superset)[0]\n",
-    "loaded_train = tuple(loaded_splits)[0]\n",
+    "# Verify we got the same amount of samples in the loaded split:\n",
+    "original_train = tuple(subsets['predefined'])[0]\n",
+    "loaded_train = tuple(loaded_splits['predefined'])[0]\n",
     "\n",
     "original_count = len(original_train.assays[0].records)\n",
     "loaded_count = len(loaded_train.assays[0].records)\n",
@@ -599,17 +681,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Training set: 738 sequences\n",
-      "First training sequence: ITLIELMIVIAIVGILAAVALPAYQDYTARAQVSEAILLAEGQKSAVTEYYLNHGEWPGDNSSAGVATSADIKGKYVQSVTVANGVITAQMASSNVNNEIKSKKLSLWAKRQNGSVKWFCGQPVTRTTATATDVAAANGKTDDKINTKHLPSTCRDDSSAS...\n",
-      "First training target: -3.5980000000000003\n",
+      "Training set: 533 sequences\n",
+      "First training sequence: LTLIELMIVIAIVGILAAVALPAYQDYTARAQVSEAILLAEGQKSAVTEYYLNHGEWPGDNSSAGVATSADIKGKYVQSVTVANGVITAQMASSNVNNEIKSKKLSLWAKRQNGSVKWFCGQPVTRTTATATDVAAANGKTDDKINTKHLPSTCRDDSSAS...\n",
+      "First training target: -0.6779999999999999\n",
       "\n",
-      "Test set: 92 sequences\n"
+      "Test set: 196 sequences\n"
      ]
     }
    ],
    "source": [
     "# Example: Extract training and test data for ML\n",
-    "train_dataset, val_dataset, test_dataset = tuple(split_superset)\n",
+    "train_dataset, val_dataset, test_dataset = tuple(loaded_splits['predefined'])\n",
     "\n",
     "# Extract sequences and targets from training set\n",
     "train_records = train_dataset.assays[0].records\n",
@@ -644,21 +726,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Fold 1: 11 train, 185 test → Score: 0.850\n",
-      "Fold 2: 11 train, 185 test → Score: 0.870\n",
-      "Fold 3: 12 train, 184 test → Score: 0.890\n",
-      "Fold 4: 12 train, 184 test → Score: 0.910\n",
-      "Fold 5: 12 train, 184 test → Score: 0.930\n",
+      "Fold 1: 156 train, 40 test → Score: 0.850\n",
+      "Fold 2: 157 train, 39 test → Score: 0.870\n",
+      "Fold 3: 157 train, 39 test → Score: 0.890\n",
+      "Fold 4: 157 train, 39 test → Score: 0.910\n",
+      "Fold 5: 157 train, 39 test → Score: 0.930\n",
       "\n",
       "Mean CV Score: 0.890\n"
      ]
     }
    ],
    "source": [
-    "# Example: Cross-validation workflow\n",
+    "# Create 5-fold cross-validation splits\n",
+    "subsets = Subsets(dataset=dataset)\n",
+    "kfold_splitter = KFoldSplitter(n_splits=5, shuffle=True)\n",
+    "subsets.update(kfold=kfold_splitter.split(dataset=dataset))\n",
+    "\n",
+    "# Cross-validation workflow\n",
     "cv_scores = []\n",
     "\n",
-    "for fold_idx, test_dataset in enumerate(kfold_superset):\n",
+    "for fold_idx, test_dataset in enumerate(subsets['kfold']):\n",
     "    # Get test data\n",
     "    test_records = test_dataset.assays[0].records\n",
     "    n_test = len(test_records)\n",


### PR DESCRIPTION
# Changes

In the original notebooks we often do:
```
my_splitter = RandomSplitter()
subsets = my_splitter.split(dataset=dataset)
```

But this returns slices as list[DatasetSlice], which is more annoying to work with when updating slices. So changed the examples to properly initialize a Subset and update that instead:

```
subsets = Subsets(dataset)
my_splitter = RandomSplitter()
subsets.update(my_split_key=my_splitter.split(dataset)
```
and this returns slices as dict[str, list[DatasetSlice]] which allows for cleaner/easier use.

# Checklist

- [x] I broke the PR down so that it contains a reasonable amount of changes for an effective review
- [x] I performed a self-review of my code. Amongst other things, I have commented my code in hard-to-understand areas.
- [x] I made corresponding changes to the documentation
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I accounted for dependent changes to be merged and published in downstream modules
