### PR TITLE
Remove evedesign dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "scikit-learn>=1.5.0,<2.0.0",
     "pandas>=2.3.3",
     "requests>=2.32.3",
-    "evedesign>=0.0.4",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Removed evedesign dependency from project requirements.

# Changes

Forgot to remove evedesign from pyproject.toml a couple of PRs ago

Please include a summary of the changes and the related issue. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

# Checklist

- [ ] I broke the PR down so that it contains a reasonable amount of changes for an effective review
- [ ] I performed a self-review of my code. Amongst other things, I have commented my code in hard-to-understand areas.
- [ ] I made corresponding changes to the documentation
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I accounted for dependent changes to be merged and published in downstream modules
