### PR TITLE
Adding metadata attributes to DatasetSlice and AssaySlice classes

### DIFF
--- a/src/proteingym/base/assay.py
+++ b/src/proteingym/base/assay.py
@@ -453,7 +453,10 @@ class AssaySlice:
     """The boolean mask for the records. If None, all records are included."""
 
     metadata: dict[str, Union[str, float]] | None = None
-    """Metadata associated with the AssaySlice."""
+    """Metadata associated with the AssaySlice. The metadata can be used to describe
+    details about the slice, for instance properties of the slice, like the number of 
+    top performing variants contained in the assay slice, or any other information 
+    relevant to the user."""
 
     @classmethod
     def from_json(cls, contents: str) -> "AssaySlice":

--- a/src/proteingym/base/assay.py
+++ b/src/proteingym/base/assay.py
@@ -5,7 +5,7 @@ import json
 from collections.abc import Collection
 from enum import StrEnum
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Union
 
 import annotated_types
 import polars as pl
@@ -452,6 +452,9 @@ class AssaySlice:
     records: list[bool] | None = None
     """The boolean mask for the records. If None, all records are included."""
 
+    metadata: dict[str, Union[str, float]] | None = None
+    """Metadata associated with the AssaySlice."""
+
     @classmethod
     def from_json(cls, contents: str) -> "AssaySlice":
         """Create an assay slice from a JSON string.
@@ -481,12 +484,18 @@ class AssaySlice:
 
         if n_items <= 5:
             records_repr = "[" + ", ".join(repr(x) for x in self.records) + "]"
-            return f"AssaySlice(columns={self.columns}, records={records_repr})"
+            return (
+                f"AssaySlice(columns={self.columns}, records={records_repr}, "
+                f"metadata={self.metadata})"
+            )
         else:
             records_repr = (
                 f"[{self.records[0]}, ..., {self.records[-1]}] (len={n_items})"
             )
-            return f"AssaySlice(columns={self.columns}, records={records_repr})"
+            return (
+                f"AssaySlice(columns={self.columns}, records={records_repr}, "
+                f"metadata={self.metadata})"
+            )
 
 
 @dataclasses.dataclass(kw_only=True, frozen=True)

--- a/src/proteingym/base/assay.py
+++ b/src/proteingym/base/assay.py
@@ -5,7 +5,7 @@ import json
 from collections.abc import Collection
 from enum import StrEnum
 from pathlib import Path
-from typing import Annotated, Union
+from typing import Annotated
 
 import annotated_types
 import polars as pl
@@ -452,10 +452,10 @@ class AssaySlice:
     records: list[bool] | None = None
     """The boolean mask for the records. If None, all records are included."""
 
-    metadata: dict[str, Union[str, float]] | None = None
+    metadata: dict[str, str | float] | None = None
     """Metadata associated with the AssaySlice. The metadata can be used to describe
-    details about the slice, for instance properties of the slice, like the number of 
-    top performing variants contained in the assay slice, or any other information 
+    details about the slice, for instance properties of the slice, like the number of
+    top performing variants contained in the assay slice, or any other information
     relevant to the user."""
 
     @classmethod

--- a/src/proteingym/base/dataset.py
+++ b/src/proteingym/base/dataset.py
@@ -66,7 +66,11 @@ class DatasetSlice:
     """The list of assay slices. If None, all assays are included."""
 
     metadata: dict[str, Union[str, float]] | None = None
-    """Metadata associated with the DatasetSlice."""
+    """Metadata associated with the DatasetSlice. The metadata can be used to describe
+    details about the slice, for instance properties of the slice, like the number of 
+    top performing variants contained in the dataset slice, or with what kind of 
+    splitting parameters the slice was created, or any other information relevant to the 
+    user."""
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "DatasetSlice":

--- a/src/proteingym/base/dataset.py
+++ b/src/proteingym/base/dataset.py
@@ -6,7 +6,7 @@ import warnings
 from collections.abc import Callable, Collection
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Iterator
+from typing import Any, Iterator, Union
 from zipfile import ZipFile
 
 import polars as pl
@@ -65,6 +65,9 @@ class DatasetSlice:
     assays: list[AssaySlice | list[bool | str]] | None = None
     """The list of assay slices. If None, all assays are included."""
 
+    metadata: dict[str, Union[str, float]] | None = None
+    """Metadata associated with the DatasetSlice."""
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "DatasetSlice":
         """Create a dataset slice from a dictionary.
@@ -81,7 +84,7 @@ class DatasetSlice:
             assays = None
         else:
             assays = [AssaySlice(**assay) for assay in data.get("assays", [])]
-        return cls(assays=assays)
+        return cls(assays=assays, metadata=data.get("metadata"))
 
     @classmethod
     def from_json(cls, contents: str) -> "DatasetSlice":
@@ -105,6 +108,7 @@ class DatasetSlice:
         data = {}
         if self.assays is not None:
             data["assays"] = [dataclasses.asdict(slc) for slc in self.assays]
+        data["metadata"] = self.metadata
         return json.dumps(data)
 
 

--- a/src/proteingym/base/dataset.py
+++ b/src/proteingym/base/dataset.py
@@ -6,7 +6,7 @@ import warnings
 from collections.abc import Callable, Collection
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Iterator, Union
+from typing import Any, Iterator
 from zipfile import ZipFile
 
 import polars as pl
@@ -65,12 +65,12 @@ class DatasetSlice:
     assays: list[AssaySlice | list[bool | str]] | None = None
     """The list of assay slices. If None, all assays are included."""
 
-    metadata: dict[str, Union[str, float]] | None = None
+    metadata: dict[str, str | float] | None = None
     """Metadata associated with the DatasetSlice. The metadata can be used to describe
-    details about the slice, for instance properties of the slice, like the number of 
-    top performing variants contained in the dataset slice, or with what kind of 
-    splitting parameters the slice was created, or any other information relevant to the 
-    user."""
+    details about the slice, for instance properties of the slice, like the number of
+    top performing variants contained in the dataset slice, or with what kind of
+    splitting parameters the slice was created, or any other information relevant to
+    the user."""
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "DatasetSlice":

--- a/tests/test_assay.py
+++ b/tests/test_assay.py
@@ -413,7 +413,10 @@ def test_assay_slice_from_json_mask_records_only(contents: str) -> None:
 
 def test_assay_slice_to_json_columns_and_records_and_metadata() -> None:
     """Test that an assay slice is correctly dumped to JSON."""
-    contents = '{"columns": ["sequence", "DMS Score"], "records": [true, false, true], "metadata": {"k": 14}}'
+    contents = (
+        '{"columns": ["sequence", "DMS Score"], "records": [true, false, true], '
+        '"metadata": {"k": 14}}'
+    )
     slc = AssaySlice(
         columns=["sequence", "DMS Score"],
         records=[True, False, True],
@@ -423,8 +426,12 @@ def test_assay_slice_to_json_columns_and_records_and_metadata() -> None:
 
 
 def test_assay_slice_to_json_columns_and_records() -> None:
-    """Test that an assay slice with only columns and records is correctly dumped to JSON."""
-    contents = '{"columns": ["sequence", "DMS Score"], "records": [true, false, true], "metadata": null}'
+    """Test that an assay slice with only columns and records is correctly dumped to
+    JSON."""
+    contents = (
+        '{"columns": ["sequence", "DMS Score"], "records": [true, false, true], '
+        '"metadata": null}'
+    )
     slc = AssaySlice(columns=["sequence", "DMS Score"], records=[True, False, True])
     assert slc.to_json() == contents
 
@@ -1669,14 +1676,15 @@ def test_assay_slice_repr_records_short_list():
     r = repr(slc)
     assert (
         r
-        == "AssaySlice(columns=['sequence'], records=[True, False, True, False, True], metadata=None)"
+        == "AssaySlice(columns=['sequence'], records=[True, False, True, False, True], "
+        "metadata=None)"
     )
 
     slc2 = AssaySlice(columns=None, records=[False, False, False, False, False])
     r2 = repr(slc2)
     assert (
-        r2
-        == "AssaySlice(columns=None, records=[False, False, False, False, False], metadata=None)"
+        r2 == "AssaySlice(columns=None, records=[False, False, False, False, False], "
+        "metadata=None)"
     )
 
 

--- a/tests/test_assay.py
+++ b/tests/test_assay.py
@@ -372,6 +372,21 @@ def test_assay_manifest_section_validate_feature_names(assay_file: Path) -> None
         )
 
 
+def test_assay_slice_from_json_columns_and_records_and_metadata() -> None:
+    """Test that an assay slice can be created from a JSON string."""
+    expected = AssaySlice(
+        columns=["sequence", "DMS Score"],
+        records=[True, False, True],
+        metadata={"k": 14},
+    )
+    contents = (
+        '{"columns": ["sequence", "DMS Score"], "records": [true, false, true], '
+        '"metadata": {"k": 14}}'
+    )
+    slc = AssaySlice.from_json(contents)
+    assert slc == expected
+
+
 def test_assay_slice_from_json_columns_and_records() -> None:
     """Test that an assay slice can be created from a JSON string."""
     expected = AssaySlice(
@@ -396,16 +411,29 @@ def test_assay_slice_from_json_mask_records_only(contents: str) -> None:
     assert slc == expected
 
 
-def test_assay_slice_to_json_columns_and_records() -> None:
+def test_assay_slice_to_json_columns_and_records_and_metadata() -> None:
     """Test that an assay slice is correctly dumped to JSON."""
-    contents = '{"columns": ["sequence", "DMS Score"], "records": [true, false, true]}'
+    contents = '{"columns": ["sequence", "DMS Score"], "records": [true, false, true], "metadata": {"k": 14}}'
+    slc = AssaySlice(
+        columns=["sequence", "DMS Score"],
+        records=[True, False, True],
+        metadata={"k": 14},
+    )
+    assert slc.to_json() == contents
+
+
+def test_assay_slice_to_json_columns_and_records() -> None:
+    """Test that an assay slice with only columns and records is correctly dumped to JSON."""
+    contents = '{"columns": ["sequence", "DMS Score"], "records": [true, false, true], "metadata": null}'
     slc = AssaySlice(columns=["sequence", "DMS Score"], records=[True, False, True])
     assert slc.to_json() == contents
 
 
 def test_assay_slice_to_json_with_columns_only() -> None:
     """Test that an assay slice with columns only is correctly dumped to JSON."""
-    contents = '{"columns": ["sequence", "DMS Score"], "records": null}'
+    contents = (
+        '{"columns": ["sequence", "DMS Score"], "records": null, "metadata": null}'
+    )
     slc = AssaySlice(columns=["sequence", "DMS Score"])
     assert slc.to_json() == contents
 
@@ -1641,12 +1669,15 @@ def test_assay_slice_repr_records_short_list():
     r = repr(slc)
     assert (
         r
-        == "AssaySlice(columns=['sequence'], records=[True, False, True, False, True])"
+        == "AssaySlice(columns=['sequence'], records=[True, False, True, False, True], metadata=None)"
     )
 
     slc2 = AssaySlice(columns=None, records=[False, False, False, False, False])
     r2 = repr(slc2)
-    assert r2 == "AssaySlice(columns=None, records=[False, False, False, False, False])"
+    assert (
+        r2
+        == "AssaySlice(columns=None, records=[False, False, False, False, False], metadata=None)"
+    )
 
 
 def test_assay_slice_repr_records_truncated():
@@ -1656,10 +1687,14 @@ def test_assay_slice_repr_records_truncated():
     r = repr(slc)
     assert r == (
         "AssaySlice(columns=['sequence', 'DMS Score'], "
-        "records=[False, ..., False] (len=10))"
+        "records=[False, ..., False] (len=10), "
+        "metadata=None)"
     )
 
     records2 = [True] * 20
     slc2 = AssaySlice(columns=None, records=records2)
     r2 = repr(slc2)
-    assert r2 == "AssaySlice(columns=None, records=[True, ..., True] (len=20))"
+    assert (
+        r2
+        == "AssaySlice(columns=None, records=[True, ..., True] (len=20), metadata=None)"
+    )

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -22,11 +22,11 @@ def test_dataset_slice_from_dict() -> None:
             AssaySlice(records=[True, False, True]),
             AssaySlice(records=[False, True, False]),
         ],
-        metadata={"fraction": 0.8}
+        metadata={"fraction": 0.8},
     )
     contents = {
         "assays": [{"records": [True, False, True]}, {"records": [False, True, False]}],
-        "metadata": {"fraction": 0.8}
+        "metadata": {"fraction": 0.8},
     }
     slc = DatasetSlice.from_dict(contents)
     assert slc == expected

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -21,10 +21,12 @@ def test_dataset_slice_from_dict() -> None:
         assays=[
             AssaySlice(records=[True, False, True]),
             AssaySlice(records=[False, True, False]),
-        ]
+        ],
+        metadata={"fraction": 0.8}
     )
     contents = {
-        "assays": [{"records": [True, False, True]}, {"records": [False, True, False]}]
+        "assays": [{"records": [True, False, True]}, {"records": [False, True, False]}],
+        "metadata": {"fraction": 0.8}
     }
     slc = DatasetSlice.from_dict(contents)
     assert slc == expected
@@ -51,8 +53,9 @@ def test_dataset_slice_dumps_mask() -> None:
     """Test that a dataset slice with a boolean mask is correctly dumped to JSON."""
     contents = (
         '{"assays": ['
-        '{"columns": null, "records": [true, false, true]}, '
-        '{"columns": null, "records": [false, true, false]}]}'
+        '{"columns": null, "records": [true, false, true], "metadata": null}, '
+        '{"columns": null, "records": [false, true, false], "metadata": null}], '
+        '"metadata": null}'
     )
     slc = DatasetSlice(
         assays=[


### PR DESCRIPTION
# Changes

Allows users to tag their slices with metadata. This is useful when users want to add:

- Splitting parameters
    - `fraction` for random splitting
    - `quantile` for quantile splitting
- Properties of the resulting slice
    - `top_k` for QuantileSplitting
- Annotation/description of slices created in usage other than splitting.


# Checklist

- [x] I broke the PR down so that it contains a reasonable amount of changes for an effective review
- [x] I performed a self-review of my code. Amongst other things, I have commented my code in hard-to-understand areas.
- [ ] I made corresponding changes to the documentation
- [x] I added tests that prove my fix is effective or that my feature works
- [ ] I accounted for dependent changes to be merged and published in downstream modules
