### PR TITLE
Adding a predictions_delta method to the Dataset class for representing model predictions

### DIFF
--- a/src/proteingym/base/dataset.py
+++ b/src/proteingym/base/dataset.py
@@ -944,17 +944,6 @@ class Dataset(BaseModel):
         # Get the target field
         target_field = next(t for t in self.assay_targets if t.name == target)
 
-        # Sanitize target_field: empty string descriptions cause manifest validation
-        # errors, so convert them to None
-        if target_field.description == "":
-            target_field = dataclasses.replace(target_field, description=None)
-
-        # Sanitize assay_variables: same issue with empty descriptions
-        sanitized_variables = [
-            dataclasses.replace(v, description=None) if v.description == "" else v
-            for v in self.assay_variables
-        ]
-
         # Build prediction lookup from df (sequence string -> predicted value)
         # Use a dict for O(1) lookup per record
         predictions = {
@@ -1002,8 +991,7 @@ class Dataset(BaseModel):
                 predicted_value = predictions.get(seq_str)
                 new_records.append((sequence_obj, predicted_value))
 
-            # Build new fields: sequence + sanitized target field
-            # Use the sanitized target_field to ensure description consistency
+            # Build new fields: sequence + target field
             new_fields = [sequence_field, target_field]
 
             new_assays.append(
@@ -1021,7 +1009,7 @@ class Dataset(BaseModel):
                 "name": f"{self.name}_predictions",
                 "description": None,
                 "reference_sequence_name": None,
-                "assay_variables": sanitized_variables,
+                "assay_variables": self.assay_variables,
                 "assay_targets": [target_field],
                 "assays": new_assays,
                 "assays_raw": [],
@@ -1037,9 +1025,9 @@ class Dataset(BaseModel):
 def dummy_dataset() -> Dataset:
     """Create a trivial dataset for illustrative purposes."""
     fields = [
-        Field(name=SEQUENCE, description=""),
-        Field(name="numerical", description=""),
-        Field(name="categorical", description=""),
+        Field(name=SEQUENCE, description="Protein sequence field."),
+        Field(name="numerical", description="Numerical assay variable field."),
+        Field(name="categorical", description="Categorical assay variable field."),
     ]
     sequence1 = Sequence(
         name="seq1",
@@ -1067,10 +1055,10 @@ def dummy_dataset() -> Dataset:
     dataset = Dataset(
         name="dataset_with_single_assay",
         description="A dataset containing a single assay.",
-        assay_variables=[Field(name="var1", description="")],
+        assay_variables=[Field(name="var1", description="Assay variable.")],
         assay_targets=[
-            Field(name="numerical", description=""),
-            Field(name="categorical", description=""),
+            Field(name="numerical", description="Numerical assay measurement."),
+            Field(name="categorical", description="Numerical assay measurement."),
         ],
         assays=[assay],
         sequences=[],

--- a/src/proteingym/base/dataset.py
+++ b/src/proteingym/base/dataset.py
@@ -911,7 +911,9 @@ class Dataset(BaseModel):
         Raises:
             ValueError: If ``target`` is not a valid assay target name.
             ValueError: If ``df`` is missing required columns (``sequence`` or
-            ``target``).
+                ``target``).
+            ValueError: If``df`` contains predictions for sequences that are not in the
+                original data and ``allow_extra_predictions`` set to false.
 
         Examples:
             >>> dataset = dummy_dataset()

--- a/src/proteingym/base/dataset.py
+++ b/src/proteingym/base/dataset.py
@@ -887,12 +887,12 @@ class Dataset(BaseModel):
         IMPORTANT: Because this method matches records to predictions only using the
         sequence string, this means that sequences measured under varying assay
         variables will be assigned the same value. This mirrors the behavior from the
-        `to_df` method.
+        ``to_df`` method.
 
         Args:
             df: A DataFrame containing predictions. Must have:
                 - A ``sequence`` column with protein sequence strings
-                - A column named ``target`` with the predicted values
+                - A column named with the value of ``target`` with the predicted values
                 Rows in ``df`` that don't match any sequence in the dataset are ignored.
             target: The name of the target being predicted. Must be a valid assay target
                 name (present in ``self.assay_targets``).

--- a/src/proteingym/base/dataset.py
+++ b/src/proteingym/base/dataset.py
@@ -950,12 +950,12 @@ class Dataset(BaseModel):
             row[0]: row[1] for row in df.select([SEQUENCE, target]).iter_rows()
         }
 
-        # Warn if many predictions don't match any assay sequences
+        # Warn if predictions don't match any assay sequences
         all_sequences = set()
         for assay in self.assays:
             all_sequences.update(str(record[0].value) for record in assay.records)
         unused = set(predictions.keys()) - all_sequences
-        if unused and len(unused) / len(predictions) > 0.1:
+        if unused:
             warnings.warn(
                 f"{len(unused)}/{len(predictions)} predictions "
                 f"({len(unused) / len(predictions):.1%}) don't match any sequence in "

--- a/src/proteingym/base/dataset.py
+++ b/src/proteingym/base/dataset.py
@@ -867,6 +867,172 @@ class Dataset(BaseModel):
         df = df.group_by(group_cols).agg(agg_exprs).sort(group_cols)
         return df
 
+    def predictions_delta(
+        self,
+        df: pl.DataFrame,
+        *,
+        target: str,
+    ) -> "Dataset":
+        """Return a delta dataset with target values replaced by predictions from `df`.
+
+        This method creates a minimal "predictions" dataset suitable for scoring against
+        the ground truth. The delta preserves the exact assay structure (count, order,
+        and per-assay record count/order) to enable applying the same `DatasetSlice`
+        objects used for cross-validation, but strips all metadata and non-predicted
+        attributes.
+
+        Records are matched to predictions by the sequence string. Records without a
+        matching prediction receive `None` (null) for the target value.
+
+        IMPORTANT: Because this method matches records to predictions only using the
+        sequence string, this means that sequences measured under varying assay
+        variables will be assigned the same value. This mirrors the behavior from the
+        `to_df` method.
+
+        Args:
+            df: A DataFrame containing predictions. Must have:
+                - A ``sequence`` column with protein sequence strings
+                - A column named ``target`` with the predicted values
+                Rows in ``df`` that don't match any sequence in the dataset are ignored.
+            target: The name of the target being predicted. Must be a valid assay target
+                name (present in ``self.assay_targets``).
+
+        Returns:
+            Dataset: A new dataset with:
+                - Identical assay structure (same count, order, record counts)
+                - Target values replaced with predictions (or null if no prediction)
+                - Only ``sequence`` and ``target`` fields per assay
+                - Stripped metadata (sequences, structures, MSAs, publication, etc.)
+
+        Raises:
+            ValueError: If ``target`` is not a valid assay target name.
+            ValueError: If ``df`` is missing required columns (``sequence`` or
+            ``target``).
+
+        Examples:
+            >>> dataset = dummy_dataset()
+            >>> predictions_df = pl.DataFrame({
+            ...     "sequence": ["ACDEFG", "GFEDCA"],
+            ...     "numerical": [1.2, 2.3]
+            ... })
+            >>> delta = dataset.predictions_delta(predictions_df, target="numerical")
+            >>> delta.to_df(target_names="numerical")
+            shape: (2, 3)
+            ┌──────────┬──────┬───────────┐
+            │ sequence ┆ var1 ┆ numerical │
+            │ ---      ┆ ---  ┆ ---       │
+            │ str      ┆ i32  ┆ f64       │
+            ╞══════════╪══════╪═══════════╡
+            │ ACDEFG   ┆ 2    ┆ 1.2       │
+            │ GFEDCA   ┆ 2    ┆ 2.3       │
+            └──────────┴──────┴───────────┘
+        """
+        # Validate target
+        valid_target_names = {t.name for t in self.assay_targets}
+        if target not in valid_target_names:
+            raise ValueError(
+                f"Target '{target}' is not a valid assay target. "
+                f"Valid targets: {', '.join(sorted(valid_target_names))}"
+            )
+
+        # Validate DataFrame columns
+        if SEQUENCE not in df.columns:
+            raise ValueError(f"DataFrame must have a '{SEQUENCE}' column.")
+        if target not in df.columns:
+            raise ValueError(f"DataFrame must have a '{target}' column.")
+
+        # Get the target field
+        target_field = next(t for t in self.assay_targets if t.name == target)
+
+        # Sanitize target_field: empty string descriptions cause manifest validation
+        # errors, so convert them to None
+        if target_field.description == "":
+            target_field = dataclasses.replace(target_field, description=None)
+
+        # Sanitize assay_variables: same issue with empty descriptions
+        sanitized_variables = [
+            dataclasses.replace(v, description=None) if v.description == "" else v
+            for v in self.assay_variables
+        ]
+
+        # Build prediction lookup from df (sequence string -> predicted value)
+        # Use a dict for O(1) lookup per record
+        predictions = {
+            row[0]: row[1] for row in df.select([SEQUENCE, target]).iter_rows()
+        }
+
+        # Warn if many predictions don't match any assay sequences
+        all_sequences = set()
+        for assay in self.assays:
+            all_sequences.update(str(record[0].value) for record in assay.records)
+        unused = set(predictions.keys()) - all_sequences
+        if unused and len(unused) / len(predictions) > 0.1:
+            warnings.warn(
+                f"{len(unused)}/{len(predictions)} predictions "
+                f"({len(unused) / len(predictions):.1%}) don't match any sequence in "
+                f"the dataset.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+        # Create new assays with predictions
+        new_assays = []
+        sequence_field = Field(name=SEQUENCE)
+
+        for assay in self.assays:
+            if target not in assay.target_feature_names:
+                # This assay doesn't have the target — create records with all nulls
+                new_records = [(record[0], None) for record in assay.records]
+                new_fields = [sequence_field, target_field]
+                new_assays.append(
+                    dataclasses.replace(
+                        assay,
+                        records=new_records,
+                        fields=new_fields,
+                        non_targets=[],
+                    )
+                )
+                continue
+
+            # Create new records: reuse Sequence object, lookup prediction
+            new_records = []
+            for record in assay.records:
+                sequence_obj = record[0]
+                seq_str = str(sequence_obj.value)
+                predicted_value = predictions.get(seq_str)
+                new_records.append((sequence_obj, predicted_value))
+
+            # Build new fields: sequence + sanitized target field
+            # Use the sanitized target_field to ensure description consistency
+            new_fields = [sequence_field, target_field]
+
+            new_assays.append(
+                dataclasses.replace(
+                    assay,
+                    records=new_records,
+                    fields=new_fields,
+                    non_targets=[],
+                )
+            )
+
+        # Return delta dataset with stripped metadata
+        return self.model_copy(
+            update={
+                "name": f"{self.name}_predictions",
+                "description": None,
+                "reference_sequence_name": None,
+                "assay_variables": sanitized_variables,
+                "assay_targets": [target_field],
+                "assays": new_assays,
+                "assays_raw": [],
+                "sequences": [],
+                "structures": [],
+                "msas": [],
+                "msa_weights": [],
+                "publication": None,
+            }
+        )
+
 
 def dummy_dataset() -> Dataset:
     """Create a trivial dataset for illustrative purposes."""

--- a/src/proteingym/base/dataset.py
+++ b/src/proteingym/base/dataset.py
@@ -955,13 +955,12 @@ class Dataset(BaseModel):
         for assay in self.assays:
             all_sequences.update(str(record[0].value) for record in assay.records)
         unused = set(predictions.keys()) - all_sequences
-        if unused:
-            if not allow_extra_predictions:
-                raise ValueError(
-                    f"{len(unused)}/{len(predictions)} predictions "
-                    f"({len(unused) / len(predictions):.1%}) don't match any sequence "
-                    f"in the dataset."
-                )
+        if unused and not allow_extra_predictions:
+            raise ValueError(
+                f"{len(unused)}/{len(predictions)} predictions "
+                f"({len(unused) / len(predictions):.1%}) don't match any sequence "
+                f"in the dataset."
+            )
 
         new_assays = []
         sequence_field = Field(name=SEQUENCE)

--- a/src/proteingym/base/dataset.py
+++ b/src/proteingym/base/dataset.py
@@ -1025,9 +1025,9 @@ class Dataset(BaseModel):
 def dummy_dataset() -> Dataset:
     """Create a trivial dataset for illustrative purposes."""
     fields = [
-        Field(name=SEQUENCE, description="Protein sequence field."),
-        Field(name="numerical", description="Numerical assay variable field."),
-        Field(name="categorical", description="Categorical assay variable field."),
+        Field(name=SEQUENCE, description=None),
+        Field(name="numerical", description=None),
+        Field(name="categorical", description=None),
     ]
     sequence1 = Sequence(
         name="seq1",
@@ -1055,10 +1055,10 @@ def dummy_dataset() -> Dataset:
     dataset = Dataset(
         name="dataset_with_single_assay",
         description="A dataset containing a single assay.",
-        assay_variables=[Field(name="var1", description="Assay variable.")],
+        assay_variables=[Field(name="var1", description=None)],
         assay_targets=[
-            Field(name="numerical", description="Numerical assay measurement."),
-            Field(name="categorical", description="Numerical assay measurement."),
+            Field(name="numerical", description=None),
+            Field(name="categorical", description=None),
         ],
         assays=[assay],
         sequences=[],

--- a/src/proteingym/base/dataset.py
+++ b/src/proteingym/base/dataset.py
@@ -872,6 +872,7 @@ class Dataset(BaseModel):
         df: pl.DataFrame,
         *,
         target: str,
+        allow_extra_predictions: bool = False,
     ) -> "Dataset":
         """Return a delta dataset with target values replaced by predictions from `df`.
 
@@ -896,6 +897,9 @@ class Dataset(BaseModel):
                 Rows in ``df`` that don't match any sequence in the dataset are ignored.
             target: The name of the target being predicted. Must be a valid assay target
                 name (present in ``self.assay_targets``).
+            allow_extra_predictions: Whether to allow the dataframe to contain
+                predictions for sequences that are not in the original data (i.e.,
+                can't be matched to sequences in the assays containing ``target``).
 
         Returns:
             Dataset: A new dataset with:
@@ -927,7 +931,6 @@ class Dataset(BaseModel):
             │ GFEDCA   ┆ 2    ┆ 2.3       │
             └──────────┴──────┴───────────┘
         """
-        # Validate target
         valid_target_names = {t.name for t in self.assay_targets}
         if target not in valid_target_names:
             raise ValueError(
@@ -935,44 +938,36 @@ class Dataset(BaseModel):
                 f"Valid targets: {', '.join(sorted(valid_target_names))}"
             )
 
-        # Validate DataFrame columns
         if SEQUENCE not in df.columns:
             raise ValueError(f"DataFrame must have a '{SEQUENCE}' column.")
         if target not in df.columns:
             raise ValueError(f"DataFrame must have a '{target}' column.")
 
-        # Get the target field
         target_field = next(t for t in self.assay_targets if t.name == target)
 
-        # Build prediction lookup from df (sequence string -> predicted value)
-        # Use a dict for O(1) lookup per record
         predictions = {
             row[0]: row[1] for row in df.select([SEQUENCE, target]).iter_rows()
         }
 
-        # Warn if predictions don't match any assay sequences
         all_sequences = set()
         for assay in self.assays:
             all_sequences.update(str(record[0].value) for record in assay.records)
         unused = set(predictions.keys()) - all_sequences
         if unused:
-            warnings.warn(
-                f"{len(unused)}/{len(predictions)} predictions "
-                f"({len(unused) / len(predictions):.1%}) don't match any sequence in "
-                f"the dataset.",
-                UserWarning,
-                stacklevel=2,
-            )
+            if not allow_extra_predictions:
+                raise ValueError(
+                    f"{len(unused)}/{len(predictions)} predictions "
+                    f"({len(unused) / len(predictions):.1%}) don't match any sequence "
+                    f"in the dataset."
+                )
 
-        # Create new assays with predictions
         new_assays = []
         sequence_field = Field(name=SEQUENCE)
 
         for assay in self.assays:
             if target not in assay.target_feature_names:
-                # This assay doesn't have the target — create records with all nulls
-                new_records = [(record[0], None) for record in assay.records]
-                new_fields = [sequence_field, target_field]
+                new_records = [(record[0],) for record in assay.records]
+                new_fields = [sequence_field]
                 new_assays.append(
                     dataclasses.replace(
                         assay,
@@ -983,7 +978,6 @@ class Dataset(BaseModel):
                 )
                 continue
 
-            # Create new records: reuse Sequence object, lookup prediction
             new_records = []
             for record in assay.records:
                 sequence_obj = record[0]
@@ -991,7 +985,6 @@ class Dataset(BaseModel):
                 predicted_value = predictions.get(seq_str)
                 new_records.append((sequence_obj, predicted_value))
 
-            # Build new fields: sequence + target field
             new_fields = [sequence_field, target_field]
 
             new_assays.append(
@@ -1003,7 +996,6 @@ class Dataset(BaseModel):
                 )
             )
 
-        # Return delta dataset with stripped metadata
         return self.model_copy(
             update={
                 "name": f"{self.name}_predictions",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 from Bio.Seq import Seq
 from biotite.structure import AtomArray
 
-from proteingym.base.assay import Assay, AssayRaw, Field
+from proteingym.base.assay import Assay, AssayRaw, Field, SEQUENCE
 from proteingym.base.dataset import Dataset
 from proteingym.base.msa import MSA
 from proteingym.base.publication import Publication
@@ -506,6 +506,47 @@ def dataset_with_duplicates_sequences_across_splits() -> Dataset:
         sequences=[],
         structures=[],
         msas=[],
+    )
+    return dataset
+
+
+@pytest.fixture
+def datasets_with_different_targets_across_assays() -> Dataset:
+    seq1 = Sequence(
+        name="seq1",
+        value=Seq("ACDEFG"),
+        type=SequenceType.WILD_TYPE,
+        alphabet=SequenceAlphabet.AA,
+    )
+    seq2 = Sequence(
+        name="seq2",
+        value=Seq("GFEDCA"),
+        type=SequenceType.WILD_TYPE,
+        alphabet=SequenceAlphabet.AA,
+    )
+    assay1 = Assay(
+        name="assay_with_target_A",
+        records=[(seq1, 1.0), (seq2, 2.0)],
+        fields=[
+            Field(name=SEQUENCE, description=None),
+            Field(name="target_A", description=None),
+        ],
+    )
+    assay2 = Assay(
+        name="assay_with_target_B",
+        records=[(seq1, 10.0), (seq2, 20.0)],
+        fields=[
+            Field(name=SEQUENCE, description=None),
+            Field(name="target_B", description=None),
+        ],
+    )
+    dataset = Dataset(
+        name="multi_assay_dataset",
+        assay_targets=[
+            Field(name="target_A", description=None),
+            Field(name="target_B", description=None),
+        ],
+        assays=[assay1, assay2],
     )
     return dataset
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 from Bio.Seq import Seq
 from biotite.structure import AtomArray
 
-from proteingym.base.assay import Assay, AssayRaw, Field, SEQUENCE
+from proteingym.base.assay import SEQUENCE, Assay, AssayRaw, Field
 from proteingym.base.dataset import Dataset
 from proteingym.base.msa import MSA
 from proteingym.base.publication import Publication

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 from zipfile import ZipFile
 
+import polars as pl
 import pytest
 from Bio.Seq import Seq
 from biotite.structure import AtomArray
@@ -9,7 +10,7 @@ from typer.testing import CliRunner
 
 from proteingym.base.__main__ import app
 from proteingym.base.assay import AssaySlice
-from proteingym.base.dataset import Dataset, DatasetSlice
+from proteingym.base.dataset import Dataset, DatasetSlice, dummy_dataset
 from proteingym.base.msa import MSA, MsaProteinSequence
 from proteingym.base.sequence import Sequence, SequenceAlphabet, SequenceType
 from proteingym.base.structure import Structure
@@ -124,6 +125,11 @@ def dataset_file(tmp_path: Path) -> Path:
     dataset = Dataset(name="test_dataset")
     dataset_path = dataset.dump(path=tmp_path)
     return dataset_path
+
+
+@pytest.fixture
+def dummy_example_dataset():
+    return dummy_dataset()
 
 
 def test_list_datasets_command(runner: CliRunner, dataset_file: Path) -> None:
@@ -263,3 +269,128 @@ def test_reference_sequence_not_present_errors() -> None:
     )
     with pytest.raises(ValueError, match="not present among the dataset's sequences"):
         Dataset(name="test", reference_sequence_name="foo", sequences=[seq])
+
+
+def test_predictions_delta_basic(dummy_example_dataset) -> None:
+    """Test basic predictions_delta functionality."""
+    # Create predictions DataFrame
+    predictions_df = pl.DataFrame(
+        {"sequence": ["ACDEFG", "GFEDCA"], "numerical": [1.2, 2.3]}
+    )
+
+    delta = dummy_example_dataset.predictions_delta(predictions_df, target="numerical")
+
+    # Check structure preservation
+    assert len(delta.assays) == len(dummy_example_dataset.assays)
+    assert all(
+        len(d.records) == len(o.records)
+        for d, o in zip(delta.assays, dummy_example_dataset.assays, strict=True)
+    )
+
+    # Check metadata stripped
+    assert delta.description is None
+    assert delta.reference_sequence_name is None
+    assert len(delta.sequences) == 0
+    assert len(delta.structures) == 0
+    assert len(delta.msas) == 0
+    assert delta.publication is None
+
+    # Check assay_targets only contains predicted target
+    assert len(delta.assay_targets) == 1
+    assert delta.assay_targets[0].name == "numerical"
+
+    # Check predictions placed correctly
+    result_df = delta.to_df(target_names="numerical")
+    assert len(result_df) == 2
+    assert result_df["numerical"].to_list() == [1.2, 2.3]
+
+
+def test_predictions_delta_round_trip(dummy_example_dataset, tmp_path: Path) -> None:
+    """Test that predictions_delta output can be dumped and reloaded."""
+    predictions_df = pl.DataFrame(
+        {"sequence": ["ACDEFG", "GFEDCA"], "numerical": [1.5, 2.5]}
+    )
+
+    delta = dummy_example_dataset.predictions_delta(predictions_df, target="numerical")
+
+    # Dump and reload
+    path = delta.dump(path=tmp_path)
+    reloaded = Dataset.from_path(path)
+
+    # Check structure preserved after reload
+    assert len(reloaded.assays) == len(delta.assays)
+    assert reloaded.to_df(target_names="numerical").equals(
+        delta.to_df(target_names="numerical")
+    )
+
+
+def test_predictions_delta_missing_predictions(dummy_example_dataset) -> None:
+    """Test that records without predictions get null values."""
+    # Only predict for one sequence
+    predictions_df = pl.DataFrame({"sequence": ["ACDEFG"], "numerical": [1.2]})
+
+    delta = dummy_example_dataset.predictions_delta(predictions_df, target="numerical")
+
+    # to_df drops all-null rows, so we should only see the predicted sequence
+    result_df = delta.to_df(target_names="numerical")
+    assert len(result_df) == 1
+    assert result_df["sequence"].to_list() == ["ACDEFG"]
+    assert result_df["numerical"].to_list() == [1.2]
+
+
+def test_predictions_delta_invalid_target_raises(dummy_example_dataset) -> None:
+    """Test that invalid target name raises ValueError."""
+    predictions_df = pl.DataFrame({"sequence": ["ACDEFG"], "numerical": [1.2]})
+
+    with pytest.raises(ValueError, match="not a valid assay target"):
+        dummy_example_dataset.predictions_delta(predictions_df, target="invalid_target")
+
+
+def test_predictions_delta_missing_sequence_column_raises(
+    dummy_example_dataset,
+) -> None:
+    """Test that missing sequence column raises ValueError."""
+    predictions_df = pl.DataFrame({"numerical": [1.2]})
+
+    with pytest.raises(ValueError, match="must have a 'sequence' column"):
+        dummy_example_dataset.predictions_delta(predictions_df, target="numerical")
+
+
+def test_predictions_delta_missing_target_column_raises(dummy_example_dataset) -> None:
+    """Test that missing target column raises ValueError."""
+    predictions_df = pl.DataFrame({"sequence": ["ACDEFG"]})
+
+    with pytest.raises(ValueError, match="must have a 'numerical' column"):
+        dummy_example_dataset.predictions_delta(predictions_df, target="numerical")
+
+
+def test_predictions_delta_preserves_sequence_objects(dummy_example_dataset) -> None:
+    """Test that Sequence objects are preserved from the original dataset."""
+    predictions_df = pl.DataFrame(
+        {"sequence": ["ACDEFG", "GFEDCA"], "numerical": [1.2, 2.3]}
+    )
+
+    delta = dummy_example_dataset.predictions_delta(predictions_df, target="numerical")
+
+    # Check that Sequence objects are reused
+    original_seq = dummy_example_dataset.assays[0].records[0][0]
+    delta_seq = delta.assays[0].records[0][0]
+
+    assert delta_seq.name == original_seq.name
+    assert delta_seq.value == original_seq.value
+    assert delta_seq.type == original_seq.type
+    assert delta_seq.alphabet == original_seq.alphabet
+
+
+def test_predictions_delta_warns_on_many_unused(dummy_example_dataset) -> None:
+    """Test that a warning is issued when many predictions don't match."""
+    # Create predictions with many extra sequences
+    predictions_df = pl.DataFrame(
+        {
+            "sequence": ["ACDEFG", "GFEDCA"] + [f"SEQ{i}" for i in range(20)],
+            "numerical": [1.2, 2.3] + [float(i) for i in range(20)],
+        }
+    )
+
+    with pytest.warns(UserWarning, match="don't match any sequence"):
+        _ = dummy_example_dataset.predictions_delta(predictions_df, target="numerical")

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -9,7 +9,7 @@ from biotite.structure import AtomArray
 from typer.testing import CliRunner
 
 from proteingym.base.__main__ import app
-from proteingym.base.assay import AssaySlice
+from proteingym.base.assay import SEQUENCE, AssaySlice, Field
 from proteingym.base.dataset import Dataset, DatasetSlice, dummy_dataset
 from proteingym.base.msa import MSA, MsaProteinSequence
 from proteingym.base.sequence import Sequence, SequenceAlphabet, SequenceType
@@ -127,9 +127,7 @@ def dataset_file(tmp_path: Path) -> Path:
     return dataset_path
 
 
-@pytest.fixture
-def dummy_example_dataset():
-    return dummy_dataset()
+dummy_dataset = pytest.fixture(dummy_dataset)
 
 
 def test_list_datasets_command(runner: CliRunner, dataset_file: Path) -> None:
@@ -271,49 +269,56 @@ def test_reference_sequence_not_present_errors() -> None:
         Dataset(name="test", reference_sequence_name="foo", sequences=[seq])
 
 
-def test_predictions_delta_basic(dummy_example_dataset) -> None:
+def test_predictions_delta_basic(dummy_dataset) -> None:
     """Test basic predictions_delta functionality."""
-    # Create predictions DataFrame
+    from proteingym.base.assay import Assay
+
     predictions_df = pl.DataFrame(
         {"sequence": ["ACDEFG", "GFEDCA"], "numerical": [1.2, 2.3]}
     )
 
-    delta = dummy_example_dataset.predictions_delta(predictions_df, target="numerical")
+    delta = dummy_dataset.predictions_delta(predictions_df, target="numerical")
 
-    # Check structure preservation
-    assert len(delta.assays) == len(dummy_example_dataset.assays)
-    assert all(
-        len(d.records) == len(o.records)
-        for d, o in zip(delta.assays, dummy_example_dataset.assays, strict=True)
+    seq1 = dummy_dataset.assays[0].records[0][0]
+    seq2 = dummy_dataset.assays[0].records[2][0]
+
+    expected_assay = Assay(
+        name="assay1",
+        records=[(seq1, 1.2), (seq1, 1.2), (seq2, 2.3), (seq2, 2.3)],
+        fields=[
+            Field(name=SEQUENCE, description=None),
+            Field(name="numerical", description=None),
+        ],
+        variables={"var1": 2},
+        non_targets=[],
     )
 
-    # Check metadata stripped
-    assert delta.description is None
-    assert delta.reference_sequence_name is None
-    assert len(delta.sequences) == 0
-    assert len(delta.structures) == 0
-    assert len(delta.msas) == 0
-    assert delta.publication is None
+    expected_dataset = Dataset(
+        name="dataset_with_single_assay_predictions",
+        description=None,
+        reference_sequence_name=None,
+        assay_variables=[Field(name="var1", description=None)],
+        assay_targets=[Field(name="numerical", description=None)],
+        assays=[expected_assay],
+        assays_raw=[],
+        sequences=[],
+        structures=[],
+        msas=[],
+        msa_weights=[],
+        publication=None,
+    )
 
-    # Check assay_targets only contains predicted target
-    assert len(delta.assay_targets) == 1
-    assert delta.assay_targets[0].name == "numerical"
-
-    # Check predictions placed correctly
-    result_df = delta.to_df(target_names="numerical")
-    assert len(result_df) == 2
-    assert result_df["numerical"].to_list() == [1.2, 2.3]
+    assert delta == expected_dataset
 
 
-def test_predictions_delta_round_trip(dummy_example_dataset, tmp_path: Path) -> None:
+def test_predictions_delta_round_trip(dummy_dataset, tmp_path: Path) -> None:
     """Test that predictions_delta output can be dumped and reloaded."""
     predictions_df = pl.DataFrame(
         {"sequence": ["ACDEFG", "GFEDCA"], "numerical": [1.5, 2.5]}
     )
 
-    delta = dummy_example_dataset.predictions_delta(predictions_df, target="numerical")
+    delta = dummy_dataset.predictions_delta(predictions_df, target="numerical")
 
-    # Dump and reload
     path = delta.dump(path=tmp_path)
     reloaded = Dataset.from_path(path)
 
@@ -324,65 +329,56 @@ def test_predictions_delta_round_trip(dummy_example_dataset, tmp_path: Path) -> 
     )
 
 
-def test_predictions_delta_missing_predictions(dummy_example_dataset) -> None:
+def test_predictions_delta_missing_predictions(dummy_dataset) -> None:
     """Test that records without predictions get null values."""
     # Only predict for one sequence
     predictions_df = pl.DataFrame({"sequence": ["ACDEFG"], "numerical": [1.2]})
-
-    delta = dummy_example_dataset.predictions_delta(predictions_df, target="numerical")
-
-    # to_df drops all-null rows, so we should only see the predicted sequence
+    delta = dummy_dataset.predictions_delta(predictions_df, target="numerical")
+    expected_df = pl.DataFrame(
+        {"sequence": ["ACDEFG"], "var1": [2], "numerical": [1.2]}
+    )
     result_df = delta.to_df(target_names="numerical")
-    assert len(result_df) == 1
-    assert result_df["sequence"].to_list() == ["ACDEFG"]
-    assert result_df["numerical"].to_list() == [1.2]
+    assert result_df.equals(expected_df)
 
 
-def test_predictions_delta_invalid_target_raises(dummy_example_dataset) -> None:
+def test_predictions_delta_invalid_target_raises(dummy_dataset) -> None:
     """Test that invalid target name raises ValueError."""
     predictions_df = pl.DataFrame({"sequence": ["ACDEFG"], "numerical": [1.2]})
 
     with pytest.raises(ValueError, match="not a valid assay target"):
-        dummy_example_dataset.predictions_delta(predictions_df, target="invalid_target")
+        dummy_dataset.predictions_delta(predictions_df, target="invalid_target")
 
 
 def test_predictions_delta_missing_sequence_column_raises(
-    dummy_example_dataset,
+    dummy_dataset,
 ) -> None:
     """Test that missing sequence column raises ValueError."""
     predictions_df = pl.DataFrame({"numerical": [1.2]})
 
     with pytest.raises(ValueError, match="must have a 'sequence' column"):
-        dummy_example_dataset.predictions_delta(predictions_df, target="numerical")
+        dummy_dataset.predictions_delta(predictions_df, target="numerical")
 
 
-def test_predictions_delta_missing_target_column_raises(dummy_example_dataset) -> None:
+def test_predictions_delta_missing_target_column_raises(dummy_dataset) -> None:
     """Test that missing target column raises ValueError."""
     predictions_df = pl.DataFrame({"sequence": ["ACDEFG"]})
 
     with pytest.raises(ValueError, match="must have a 'numerical' column"):
-        dummy_example_dataset.predictions_delta(predictions_df, target="numerical")
+        dummy_dataset.predictions_delta(predictions_df, target="numerical")
 
 
-def test_predictions_delta_preserves_sequence_objects(dummy_example_dataset) -> None:
+def test_predictions_delta_preserves_sequence_objects(dummy_dataset) -> None:
     """Test that Sequence objects are preserved from the original dataset."""
     predictions_df = pl.DataFrame(
         {"sequence": ["ACDEFG", "GFEDCA"], "numerical": [1.2, 2.3]}
     )
-
-    delta = dummy_example_dataset.predictions_delta(predictions_df, target="numerical")
-
-    # Check that Sequence objects are reused
-    original_seq = dummy_example_dataset.assays[0].records[0][0]
+    delta = dummy_dataset.predictions_delta(predictions_df, target="numerical")
+    original_seq = dummy_dataset.assays[0].records[0][0]
     delta_seq = delta.assays[0].records[0][0]
-
-    assert delta_seq.name == original_seq.name
-    assert delta_seq.value == original_seq.value
-    assert delta_seq.type == original_seq.type
-    assert delta_seq.alphabet == original_seq.alphabet
+    assert delta_seq == original_seq
 
 
-def test_predictions_delta_warns_on_unused(dummy_example_dataset) -> None:
+def test_predictions_delta_raises_on_unused(dummy_dataset) -> None:
     """Test that a warning is issued when many predictions don't match."""
     # Create predictions with extra sequences
     predictions_df = pl.DataFrame(
@@ -392,31 +388,38 @@ def test_predictions_delta_warns_on_unused(dummy_example_dataset) -> None:
         }
     )
 
-    with pytest.warns(UserWarning, match="don't match any sequence"):
-        _ = dummy_example_dataset.predictions_delta(predictions_df, target="numerical")
+    with pytest.raises(ValueError, match="don't match any sequence"):
+        _ = dummy_dataset.predictions_delta(
+            predictions_df, target="numerical", allow_extra_predictions=False
+        )
 
 
-def test_predictions_delta_null_records_when_target_not_in_assay(
+def test_predictions_delta_no_target_records_when_target_not_in_assay(
     datasets_with_different_targets_across_assays,
 ) -> None:
-    """Test that assays without the target get null-valued records."""
+    """Test that assays without the target only store sequence records."""
     predictions_df = pl.DataFrame(
         {"sequence": ["ACDEFG", "GFEDCA"], "target_A": [1.5, 2.5]}
     )
-
     delta = datasets_with_different_targets_across_assays.predictions_delta(
         predictions_df, target="target_A"
     )
+    # Check assay structure
     assert len(delta.assays) == 2
-    assay1_records = delta.assays[0].records
-    assert assay1_records[0][1] == 1.5  # seq1 prediction
-    assert assay1_records[1][1] == 2.5  # seq2 prediction
 
-    assay2_records = delta.assays[1].records
-    assert assay2_records[0][1] is None  # seq1 null
-    assert assay2_records[1][1] is None  # seq2 null
+    # Check assay 1 has predictions
+    seq1 = datasets_with_different_targets_across_assays.assays[0].records[0][0]
+    seq2 = datasets_with_different_targets_across_assays.assays[0].records[1][0]
+    expected_records_assay1 = [(seq1, 1.5), (seq2, 2.5)]
+    assert delta.assays[0].records == expected_records_assay1
 
-    assert len(delta.assays[0].fields) == 2
-    assert len(delta.assays[1].fields) == 2
-    assert delta.assays[0].fields[1].name == "target_A"
-    assert delta.assays[1].fields[1].name == "target_A"
+    # Check assay 1 fields
+    expected_fields_assay1 = [
+        Field(name=SEQUENCE, description=None),
+        Field(name="target_A", description=None),
+    ]
+    assert delta.assays[0].fields == expected_fields_assay1
+
+    # Check assay 2 only has sequence field (no target since target_A not in assay 2)
+    expected_fields_assay2 = [Field(name=SEQUENCE, description=None)]
+    assert delta.assays[1].fields == expected_fields_assay2

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -394,3 +394,29 @@ def test_predictions_delta_warns_on_many_unused(dummy_example_dataset) -> None:
 
     with pytest.warns(UserWarning, match="don't match any sequence"):
         _ = dummy_example_dataset.predictions_delta(predictions_df, target="numerical")
+
+
+def test_predictions_delta_null_records_when_target_not_in_assay(
+    datasets_with_different_targets_across_assays,
+) -> None:
+    """Test that assays without the target get null-valued records."""
+    predictions_df = pl.DataFrame(
+        {"sequence": ["ACDEFG", "GFEDCA"], "target_A": [1.5, 2.5]}
+    )
+
+    delta = datasets_with_different_targets_across_assays.predictions_delta(
+        predictions_df, target="target_A"
+    )
+    assert len(delta.assays) == 2
+    assay1_records = delta.assays[0].records
+    assert assay1_records[0][1] == 1.5  # seq1 prediction
+    assert assay1_records[1][1] == 2.5  # seq2 prediction
+
+    assay2_records = delta.assays[1].records
+    assert assay2_records[0][1] is None  # seq1 null
+    assert assay2_records[1][1] is None  # seq2 null
+
+    assert len(delta.assays[0].fields) == 2
+    assert len(delta.assays[1].fields) == 2
+    assert delta.assays[0].fields[1].name == "target_A"
+    assert delta.assays[1].fields[1].name == "target_A"

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -382,9 +382,9 @@ def test_predictions_delta_preserves_sequence_objects(dummy_example_dataset) -> 
     assert delta_seq.alphabet == original_seq.alphabet
 
 
-def test_predictions_delta_warns_on_many_unused(dummy_example_dataset) -> None:
+def test_predictions_delta_warns_on_unused(dummy_example_dataset) -> None:
     """Test that a warning is issued when many predictions don't match."""
-    # Create predictions with many extra sequences
+    # Create predictions with extra sequences
     predictions_df = pl.DataFrame(
         {
             "sequence": ["ACDEFG", "GFEDCA"] + [f"SEQ{i}" for i in range(20)],


### PR DESCRIPTION
# Changes

Addresses https://github.com/ProteinGym/proteingym-benchmark/issues/173

Creates a minimal version of the original pg dataset for representing model predictions obtained by calling `dataset.predictions_delta(df, target)`, where `target` is the assay target that is predicted and `df` is a dataframe with columns `sequence` and the value of `target` containing model predictions. The method iterates over all assays in the dataset and for assays that share sequences with df AND have a target that matches the target argument, an updated assay is created with identical sequence records and predictions records storing predictions for the corresponding sequences, and null elsewhere.

The resulting `delta` pgdataset drops:
```
description
reference_sequence_name
assays_raw
sequences
structures
msas
msa_weights
publication
```

keeps:
```
assay_variables
```

and changes:

`name` to `"{name}_predictions"`
`assays` to `new_assays`
`assay_targets` to `next(t for t in self.assay_targets if t.name == target)` (Stripping all irrelevant targets)


# Checklist

- [x] I broke the PR down so that it contains a reasonable amount of changes for an effective review
- [x] I performed a self-review of my code. Amongst other things, I have commented my code in hard-to-understand areas.
- [x] I made corresponding changes to the documentation
- [x] I added tests that prove my fix is effective or that my feature works
- [ ] I accounted for dependent changes to be merged and published in downstream modules
