### PR TITLE
Add metrics module for benchmark evaluation

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,142 @@
+# Metrics
+
+Metrics quantify how well a model's predictions match the ground truth of a
+dataset. ProteinGym Base ships a small, extensible metrics framework that is
+used by the benchmark to score model predictions. This document describes how
+metrics work and how to design and add new ones.
+
+## Overview
+
+Metrics operate on a ground truth `Dataset` or `Subsets` object and a
+`predicted` `Dataset`. The framework uses **dynamic discovery**: any function in
+`proteingym.base.metrics` whose name starts with the `metric_` prefix is
+automatically discovered and made available for calculation. The part of the
+name after `metric_` becomes the metric's name.
+
+For example, a function named `metric_spearman` is exposed as the metric
+`"spearman"`, and can be requested via the `selected_metrics` argument.
+
+The following metrics are provided out of the box:
+
+| Metric     | Function          | Range        | Description                                                                 |
+|------------|-------------------|--------------|-----------------------------------------------------------------------------|
+| `spearman` | `metric_spearman` | `-1.0`–`1.0` | Spearman rank correlation between ground truth and predicted values.        |
+| `recovery` | `metric_recovery` | `0.0`–`1.0`  | Fraction of the true top-k variants that appear in the predicted top-k.     |
+
+## Calculating metrics
+
+The public API exposes three entry points:
+
+| Function                     | Purpose                                                                                             |
+|------------------------------|-----------------------------------------------------------------------------------------------------|
+| `calculate_selected_metrics` | Calculate a chosen set of metrics for a single `Dataset` or a single fold of a `Subsets` object.    |
+| `calculate_metrics_by_mode`  | Calculate metrics across scoring modes (`test`, `train_available`, `per_fold`) of a `Subsets`.      |
+| `evaluate`                   | Load ground truth and prediction archives, calculate metrics, and write the results to a JSON file. |
+
+A minimal example using `calculate_selected_metrics`:
+
+``` python
+from proteingym.base import calculate_selected_metrics
+
+results = calculate_selected_metrics(
+    selected_metrics=["spearman"],
+    ground_truth=dataset,
+    predicted=predictions,
+    target="DMS_score",
+)
+# {"spearman": 0.87}
+```
+
+When scoring a `Subsets` object, `split` and `fold` must be provided to select
+the relevant cross-validation fold:
+
+``` python
+results = calculate_selected_metrics(
+    selected_metrics=["spearman", "recovery"],
+    ground_truth=subsets,
+    predicted=predictions,
+    target="DMS_score",
+    split="random",
+    fold=0,
+)
+```
+
+## Handling `None` results
+
+A metric may return `None` when it cannot be computed for a given dataset slice.
+For example, `recovery` returns `None` when the dataset slice has no `top_k`
+metadata (typically the case for training folds). `None` values are preserved in
+the output and serialize to `null` in JSON. Metric functions should return
+`None` rather than raise when a metric is simply not applicable to the input.
+
+## Designing a new metric
+
+To add a new metric, define a function in `proteingym.base.metrics` that follows
+the metric signature below. The function is automatically discovered by its
+`metric_` prefix; no registration is required.
+
+### Signature
+
+Every metric function must accept the following parameters:
+
+| Parameter      | Type                        | Description                                                                          |
+|----------------|-----------------------------|--------------------------------------------------------------------------------------|
+| `ground_truth` | `Subsets \| Dataset`        | The ground truth data.                                                               |
+| `predicted`    | `Dataset`                   | The model predictions for the target.                                                |
+| `target`       | `str`                       | Name of the target variable to score (e.g. `"DMS_score"`).                           |
+| `split`        | `str \| None`               | Required for `Subsets`: the split strategy name (e.g. `"random"`).                   |
+| `fold`         | `int \| list[int] \| None`  | Required for `Subsets`: the fold index (or indices) within the split.                |
+
+It must return a `float`, or `None` when the metric is not applicable.
+
+### Example
+
+The following metric computes the mean absolute error between the ground truth
+and predicted values:
+
+``` python
+import numpy as np
+
+from proteingym.base.dataset import Dataset, Subsets
+from proteingym.base.metrics import prepare_and_validate_scoring_df
+
+
+def metric_mae(
+    ground_truth: Subsets | Dataset,
+    predicted: Dataset,
+    target: str,
+    split: str | None = None,
+    fold: int | list[int] | None = None,
+) -> float:
+    """Compute the mean absolute error between ground truth and predictions."""
+    scoring_df = prepare_and_validate_scoring_df(
+        ground_truth, predicted, target, split, fold
+    )
+    gt_values = scoring_df[target].to_numpy()
+    pred_values = scoring_df[f"{target}_pred"].to_numpy()
+    return float(np.mean(np.abs(gt_values - pred_values)))
+```
+
+Once defined, the metric is available under the name `"mae"`:
+
+``` python
+results = calculate_selected_metrics(
+    selected_metrics=["mae"],
+    ground_truth=dataset,
+    predicted=predictions,
+    target="DMS_score",
+)
+# {"mae": 0.12}
+```
+
+### Guidelines
+
+The following guidelines help keep metrics consistent and predictable:
+
+| Guideline                          | Motivation                                                                        |
+|------------------------------------|-----------------------------------------------------------------------------------|
+| Use `prepare_and_validate_scoring_df` | Aligns ground truth and predictions on sequence and assay variables, and validates complete prediction coverage. |
+| Read both `target` and `target_pred` columns | The scoring dataframe stores predicted values under the `_pred` suffix.   |
+| Return `None` when not applicable  | Signals "not measured" without raising; serializes to `null` in JSON.             |
+| Prefix the function name with `metric_` | Required for automatic discovery.                                            |
+| Keep the standard signature        | Enables the metric to be called uniformly by the orchestration functions.         |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -23,6 +23,96 @@ The following metrics are provided out of the box:
 | `spearman` | `metric_spearman` | `-1.0`–`1.0` | Spearman rank correlation between ground truth and predicted values.        |
 | `recovery` | `metric_recovery` | `0.0`–`1.0`  | Fraction of the true top-k variants that appear in the predicted top-k.     |
 
+## Usage
+
+You do not need the DVC benchmark pipeline to compute metrics. The metrics API
+can be used directly on any dataset archive and set of predictions, which is
+handy for quick local checks and exploration.
+
+The typical local workflow is:
+
+1. Load the ground truth dataset archive.
+2. Build a predictions `Dataset` from your model's scores using
+   [`Dataset.predictions_delta`][proteingym.base.dataset.Dataset.predictions_delta],
+   which aligns predictions to the dataset's assay structure by sequence.
+3. Call [`calculate_selected_metrics`][proteingym.base.metrics.calculate_selected_metrics].
+
+### Scoring a plain dataset
+
+``` python
+import polars as pl
+
+from proteingym.base import Dataset, calculate_selected_metrics
+
+# 1. Load the ground truth dataset archive.
+dataset = Dataset.from_path("my_dataset.pgdata")
+
+# 2. Wrap your model's predictions in a Dataset. The DataFrame needs a
+#    'sequence' column and a column named after the target being predicted.
+scores = pl.DataFrame(
+    {
+        "sequence": ["MKT...", "MKV...", "MRT..."],
+        "DMS_score": [0.12, -0.85, 1.03],
+    }
+)
+predictions = dataset.predictions_delta(scores, target="DMS_score")
+
+# 3. Calculate the metrics you care about.
+results = calculate_selected_metrics(
+    selected_metrics=["spearman"],
+    ground_truth=dataset,
+    predicted=predictions,
+    target="DMS_score",
+)
+print(results)  # {"spearman": 0.87}
+```
+
+### Scoring a single fold of a split
+
+If your dataset ships with cross-validation splits (a `.splits.pgdata`
+archive), load it as `Subsets` and pass `split` and `fold` to score a single
+fold:
+
+``` python
+from proteingym.base import Subsets, calculate_selected_metrics
+
+subsets = Subsets.from_path("my_dataset.splits.pgdata")
+predictions = subsets.dataset.predictions_delta(scores, target="DMS_score")
+
+results = calculate_selected_metrics(
+    selected_metrics=["spearman", "recovery"],
+    ground_truth=subsets,
+    predicted=predictions,
+    target="DMS_score",
+    split="random",
+    fold=0,
+)
+```
+
+### Scoring across all folds at once
+
+To reproduce the benchmark's per-mode breakdown (test fold, aggregated training
+folds, and each fold individually) without the pipeline, use
+[`calculate_metrics_by_mode`][proteingym.base.metrics.calculate_metrics_by_mode]:
+
+``` python
+from proteingym.base import calculate_metrics_by_mode
+
+results = calculate_metrics_by_mode(
+    selected_metrics=["spearman", "recovery"],
+    ground_truth=subsets,
+    predicted=predictions,
+    target="DMS_score",
+    split="random",
+    test_fold=0,
+)
+# {
+#     "test": {...},
+#     "train_available": {...},
+#     "per_fold": {"fold_0": {...}, "fold_1": {...}, ...},
+# }
+```
+
 ## Calculating metrics
 
 The public API exposes three entry points:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ plugins:
 nav:
 - Home: index.md
 - Manifest: manifest.md
+- Metrics: metrics.md
 - ADRs: decisions/
 - Tutorials:
   - Introduction: notebooks/01_Introduction_to_PG2_Dataset.ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "polars[pyarrow]>=1.30.0,<2.0.0",
     "python-frontmatter>=1.1.0",
     "scikit-learn>=1.5.0,<2.0.0",
+    "scipy>=1.16.2,<2.0.0",
     "pandas>=2.3.3",
     "requests>=2.32.3",
     "pandas-stubs~=3.0.0",

--- a/src/proteingym/base/__init__.py
+++ b/src/proteingym/base/__init__.py
@@ -9,13 +9,27 @@ Attributes :
     Manifest :
         Represents the metadata and resources of a dataset.  Entrypoint for
         loading and validating dataset from metadata.
+    evaluate :
+        Calculate performance metrics from prediction and dataset archives.
+    calculate_selected_metrics :
+        Calculate selected metrics comparing ground truth and predictions.
+    calculate_metrics_by_mode :
+        Calculate metrics across scoring modes (test, train_available, per_fold).
 """
 
 from .dataset import Dataset, Subsets
 from .manifest import Manifest
+from .metrics import (
+    calculate_metrics_by_mode,
+    calculate_selected_metrics,
+    evaluate,
+)
 
 __all__ = [
     "Dataset",
     "Manifest",
     "Subsets",
+    "calculate_metrics_by_mode",
+    "calculate_selected_metrics",
+    "evaluate",
 ]

--- a/src/proteingym/base/__main__.py
+++ b/src/proteingym/base/__main__.py
@@ -7,6 +7,7 @@ import click
 import typer
 from pydantic import ValidationError
 
+from . import metrics
 from .__about__ import __version__
 from .data_generators import (
     adjust_target_with_two_dummy_features,
@@ -287,6 +288,87 @@ def generate_data(
 
     if fmt.lower() == "csv":
         typer.echo(output.write_csv(), nl=False)
+
+
+@app.command("evaluate")
+def evaluate_metrics(
+    prediction_path: Annotated[
+        Path,
+        typer.Option(help="Path to the prediction dataset archive (.pgdata file)."),
+    ],
+    metric_path: Annotated[
+        Path,
+        typer.Option(help="Path where the calculated metrics JSON will be saved."),
+    ],
+    dataset_path: Annotated[
+        Path | None,
+        typer.Option(help="Path to the ground truth dataset archive."),
+    ] = None,
+    selected_metrics: Annotated[
+        list[str] | None,
+        typer.Option(
+            help="Metric name to calculate. Repeat the flag for multiple metrics."
+        ),
+    ] = None,
+    model_name: Annotated[
+        str | None,
+        typer.Option(help="Name of the model that generated predictions."),
+    ] = None,
+    split: Annotated[
+        str | None,
+        typer.Option(help="Name of the splitting strategy to evaluate."),
+    ] = None,
+    target: Annotated[
+        str | None,
+        typer.Option(help="Name of the target variable to score."),
+    ] = None,
+    fold: Annotated[
+        str | None,
+        typer.Option(help="Fold index designated as the test fold."),
+    ] = None,
+    score_modes: Annotated[
+        list[str] | None,
+        typer.Option(
+            help="Scoring mode to compute. Repeat the flag for multiple modes."
+        ),
+    ] = None,
+) -> None:
+    """Calculate performance metrics from predictions and save results to JSON.
+
+    Wraps ``metrics.evaluate`` to load ground truth and prediction archives,
+    compute the selected metrics, and persist the results to a JSON file.
+
+    Args:
+        prediction_path: Path to the prediction dataset archive (.pgdata file)
+            containing model predictions.
+        metric_path: Path where the calculated metrics JSON will be saved.
+        dataset_path: Path to the ground truth dataset archive (.pgdata or
+            .splits.pgdata).
+        selected_metrics: Optional list of metric names to calculate. If not
+            provided, all discovered metrics are included.
+        model_name: Name of the model that generated predictions (stored in
+            metadata).
+        split: Name of the splitting strategy to evaluate. Required for a
+            .splits.pgdata dataset.
+        target: Name of the target variable to score. Required for all metric
+            calculations.
+        fold: Fold index (as string) designated as the test fold. Required for a
+            .splits.pgdata dataset.
+        score_modes: Optional list of scoring modes to compute. Only used for a
+            .splits.pgdata dataset.
+    """
+    result_path = metrics.evaluate(
+        prediction_path=prediction_path,
+        metric_path=metric_path,
+        dataset_path=dataset_path,
+        selected_metrics=selected_metrics,
+        model_name=model_name,
+        split=split,
+        target=target,
+        fold=fold,
+        score_modes=score_modes,
+    )
+    typer.echo(f"Metrics saved to: {result_path}")
 
 
 if __name__ == "__main__":

--- a/src/proteingym/base/metrics.py
+++ b/src/proteingym/base/metrics.py
@@ -10,26 +10,8 @@ datasets or specific cross-validation folds. All metrics use a plugin-style
 architecture: any function with the ``metric_`` prefix is automatically discovered
 and made available for calculation.
 
-Adding Custom Metrics:
-    To add a new metric, define a function following this pattern::
-
-        def metric_<name>(
-            ground_truth: Subsets | Dataset,
-            predicted: Dataset,
-            target: str,
-            split: str | None = None,
-            fold: int | None = None,
-        ) -> float:
-            scoring_df = prepare_and_validate_scoring_df(
-                ground_truth, predicted, target, split, fold
-            )
-            gt_values = scoring_df[target].to_numpy()
-            pred_values = scoring_df[f"{target}_pred"].to_numpy()
-            return custom_calculation(gt_values, pred_values)
-
-    The metric function is automatically discovered and made available for
-    calculation. The function name after ``metric_`` becomes the metric name used
-    in the ``selected_metrics`` argument.
+See the [Metrics documentation](../metrics.md) for a guide on how to design and
+add new metrics.
 """
 
 import inspect

--- a/src/proteingym/base/metrics.py
+++ b/src/proteingym/base/metrics.py
@@ -1,0 +1,643 @@
+"""Metric calculation for ProteinGym benchmark evaluation.
+
+This module provides a flexible, extensible framework for calculating performance
+metrics for machine learning models on protein datasets. It uses dynamic metric
+discovery to automatically detect and execute custom metric functions.
+
+Metrics operate on :class:`~proteingym.base.dataset.Dataset` or
+:class:`~proteingym.base.dataset.Subsets` objects, enabling evaluation on complete
+datasets or specific cross-validation folds. All metrics use a plugin-style
+architecture: any function with the ``metric_`` prefix is automatically discovered
+and made available for calculation.
+
+Adding Custom Metrics:
+    To add a new metric, define a function following this pattern::
+
+        def metric_<name>(
+            ground_truth: Subsets | Dataset,
+            predicted: Dataset,
+            target: str,
+            split: str | None = None,
+            fold: int | None = None,
+        ) -> float:
+            scoring_df = prepare_and_validate_scoring_df(
+                ground_truth, predicted, target, split, fold
+            )
+            gt_values = scoring_df[target].to_numpy()
+            pred_values = scoring_df[f"{target}_pred"].to_numpy()
+            return custom_calculation(gt_values, pred_values)
+
+    The metric function is automatically discovered and made available for
+    calculation. The function name after ``metric_`` becomes the metric name used
+    in the ``selected_metrics`` argument.
+"""
+
+import inspect
+import json
+import logging
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import polars as pl
+from scipy.stats import spearmanr
+
+from .assay import SEQUENCE
+from .dataset import Dataset, DatasetSlice, Subsets
+
+logger = logging.getLogger("proteingym.base")
+
+MetricFunction = Callable[..., float | None]
+
+_metric_functions_cache: dict[str, MetricFunction] | None = None
+
+
+def _split_slices(subsets: Subsets, split: str) -> list[DatasetSlice]:
+    """Return the list of slices for a named split strategy.
+
+    Args:
+        subsets: The Subsets object containing split information.
+        split: The name of the split strategy (e.g., 'random', 'kfold_random').
+
+    Returns:
+        The list of dataset slices associated with the split.
+
+    Raises:
+        TypeError: If the subsets slices are not stored as a dictionary.
+    """
+    if not isinstance(subsets.slices, dict):
+        raise TypeError(
+            "Subsets slices must be stored as a dictionary keyed by split strategy."
+        )
+    return subsets.slices[split]
+
+
+def get_fold_indices(subsets: Subsets, split: str) -> list[int]:
+    """Get all fold indices for a given split strategy.
+
+    Args:
+        subsets: The Subsets object containing split information.
+        split: The name of the split strategy (e.g., 'random', 'kfold_random').
+
+    Returns:
+        List of fold indices available for the split.
+    """
+    return list(range(len(_split_slices(subsets, split))))
+
+
+def prepare_and_validate_scoring_df(
+    ground_truth: Subsets | Dataset,
+    predicted: Dataset,
+    target: str,
+    split: str | None = None,
+    fold: int | list[int] | None = None,
+) -> pl.DataFrame:
+    """Prepare and validate a scoring dataframe from ground truth and predictions.
+
+    Joins ground truth and predicted datasets on sequence and assay variables,
+    ensuring complete prediction coverage. The returned DataFrame contains both
+    ground truth and predicted values for the specified target, aligned by
+    sequence and variables.
+
+    Args:
+        ground_truth: The ground truth data, either as a complete Dataset or
+            a Subsets object containing dataset slices.
+        predicted: The predicted Dataset containing model predictions for the
+            target. Must have the same structure (assays and variables) as the
+            ground truth.
+        target: The name of the target variable to score (e.g., 'fitness',
+            'binding_affinity'). Must be present in both datasets' assay_targets.
+        split: Required when ground_truth is a Subsets object. The name of the
+            splitting strategy to evaluate (e.g., 'random', 'kfold_random').
+        fold: Required when ground_truth is a Subsets object. Can be:
+            - A single fold index (int) to score one fold
+            - A list of fold indices to score multiple folds in aggregate
+
+    Returns:
+        A Polars DataFrame with columns:
+            - 'sequence': The protein sequence
+            - assay variable columns (e.g., 'temperature', 'pH')
+            - target column: ground truth values
+            - target_pred column: predicted values (with '_pred' suffix)
+
+    Raises:
+        TypeError: If ground_truth is neither a Dataset nor a Subsets object.
+        ValueError: If split or fold is None when ground_truth is a Subsets object.
+        ValueError: If any ground truth records lack corresponding predictions
+            (incomplete coverage).
+    """
+    if isinstance(ground_truth, Dataset):
+        gt_df = ground_truth.to_df(target_names=target)
+        pred_df = predicted.to_df(target_names=target)
+    elif isinstance(ground_truth, Subsets):
+        if split is None or fold is None:
+            raise ValueError(
+                "Both 'split' and 'fold' must be provided when scoring Subsets."
+            )
+
+        fold_indices = [fold] if isinstance(fold, int) else fold
+
+        split_slices = _split_slices(ground_truth, split)
+        gt_dfs = []
+        pred_dfs = []
+        for fold_idx in fold_indices:
+            dataset_slice = split_slices[fold_idx]
+            gt_dfs.append(
+                ground_truth.dataset[dataset_slice].to_df(target_names=target)
+            )
+            pred_dfs.append(predicted[dataset_slice].to_df(target_names=target))
+
+        gt_df = pl.concat(gt_dfs, how="vertical_relaxed")
+        pred_df = pl.concat(pred_dfs, how="vertical_relaxed")
+    else:
+        raise TypeError("'ground_truth' must be a Dataset or a Subsets object.")
+
+    # Validate that ground_truth and predicted have the same assay_variables structure
+    if isinstance(ground_truth, Subsets):
+        gt_variables = ground_truth.dataset.assay_variables
+        pred_variables = predicted.assay_variables
+    else:
+        gt_variables = ground_truth.assay_variables
+        pred_variables = predicted.assay_variables
+
+    if gt_variables != pred_variables:
+        gt_var_names = [v.name for v in gt_variables]
+        pred_var_names = [v.name for v in pred_variables]
+        raise ValueError(
+            "Ground truth and predicted datasets must have identical assay_variables. "
+            f"Ground truth has: {gt_var_names}, predicted has: {pred_var_names}"
+        )
+
+    # Join on (sequence, variables) to align predictions with ground truth.
+    # Only use variables that are present and not all-null in both dataframes
+    # (Polars doesn't match null values in joins: NULL != NULL).
+    declared_variable_names = [v.name for v in gt_variables]
+    variable_names = [
+        var
+        for var in declared_variable_names
+        if var in gt_df.columns
+        and var in pred_df.columns
+        and not gt_df[var].is_null().all()
+        and not pred_df[var].is_null().all()
+    ]
+    join_keys = [SEQUENCE] + variable_names
+
+    joined = gt_df.join(pred_df, on=join_keys, how="inner", suffix="_pred")
+
+    missing_predictions = len(gt_df) - len(joined)
+    if missing_predictions > 0:
+        raise ValueError(f"Missing {missing_predictions} prediction(s).")
+
+    return joined
+
+
+def _get_top_k_from_slice(
+    ground_truth: Subsets | Dataset,
+    split: str | None,
+    fold: int | list[int] | None,
+) -> int | None:
+    """Extract top_k from slice metadata if available.
+
+    Args:
+        ground_truth: The ground truth data (Dataset or Subsets).
+        split: The split name (required for Subsets).
+        fold: The fold index (required for Subsets, must be int not list).
+
+    Returns:
+        The top_k value from metadata, or None if:
+            - ground_truth is not a Subsets object
+            - split or fold is not provided
+            - fold is a list (not supported for recovery)
+            - metadata doesn't exist or doesn't contain top_k
+    """
+    if not isinstance(ground_truth, Subsets):
+        return None
+    if split is None or not isinstance(fold, int):
+        return None
+    try:
+        dataset_slice = _split_slices(ground_truth, split)[fold]
+    except (KeyError, IndexError, TypeError):
+        return None
+    if dataset_slice.metadata is None:
+        return None
+    top_k = dataset_slice.metadata.get("top_k", None)
+    return int(top_k) if top_k is not None else None
+
+
+def _discover_metric_functions() -> dict[str, MetricFunction]:
+    """Discover all metric functions in the current module (cached).
+
+    Returns:
+        A mapping from metric name (the suffix after ``metric_``) to the metric
+        function.
+    """
+    global _metric_functions_cache
+    if _metric_functions_cache is None:
+        _metric_functions_cache = {}
+        current_module = sys.modules[__name__]
+        for name, obj in inspect.getmembers(current_module, inspect.isfunction):
+            if name.startswith("metric_"):
+                metric_name = name.replace("metric_", "", 1)
+                _metric_functions_cache[metric_name] = obj
+    return _metric_functions_cache
+
+
+def metric_recovery(
+    ground_truth: Subsets | Dataset,
+    predicted: Dataset,
+    target: str,
+    split: str | None = None,
+    fold: int | list[int] | None = None,
+) -> float | None:
+    """Compute the recovery metric: fraction of top-k variants correctly identified.
+
+    The recovery metric measures what fraction of the true top-k highest-value
+    variants (from ground truth) are also ranked in the top-k of predictions. This
+    metric is useful for evaluating whether a model successfully identifies the best
+    candidates, which is often more important than precise value prediction.
+
+    The top-k threshold is retrieved from the dataset slice metadata. If the metadata
+    does not contain a "top_k" value, or if ground_truth is a plain Dataset (not
+    Subsets), the metric returns None.
+
+    Note on None/NaN values: It is expected and correct for this metric to return
+    None in certain scenarios, particularly when evaluating training data. In the
+    standard workflow, top-k variants are typically only present in test folds (where
+    metadata includes "top_k"), while training folds do not have this metadata. This
+    is the intended behavior and None values should be preserved in metric outputs
+    (serialized as ``null`` in JSON).
+
+    Args:
+        ground_truth: The ground truth data, either as a complete Dataset or
+            a Subsets object containing dataset slices.
+        predicted: The predicted Dataset containing model predictions for the target.
+        target: The name of the target variable to score (e.g., 'fitness').
+        split: Required when ground_truth is a Subsets object. The name of the
+            splitting strategy to evaluate (e.g., 'random').
+        fold: Required when ground_truth is a Subsets object. The fold index
+            (0-based integer) within the specified split. Must be a single integer,
+            not a list.
+
+    Returns:
+        The recovery fraction (0.0 to 1.0) representing the fraction of true top-k
+        variants that appear in the predicted top-k, or None if top_k is not available
+        or if top_k is invalid (e.g., <= 0).
+
+    Raises:
+        TypeError: If ground_truth is neither a Dataset nor a Subsets object.
+        ValueError: If split or fold is None when ground_truth is a Subsets object.
+        ValueError: If any ground truth records lack corresponding predictions.
+        ValueError: If top_k is larger than the number of samples.
+    """
+    top_k = _get_top_k_from_slice(ground_truth, split, fold)
+    if top_k is None:
+        return None
+
+    scoring_df = prepare_and_validate_scoring_df(
+        ground_truth, predicted, target, split, fold
+    )
+
+    gt_values = scoring_df[target].to_numpy()
+    pred_values = scoring_df[f"{target}_pred"].to_numpy()
+
+    n_samples = len(gt_values)
+    if top_k > n_samples:
+        raise ValueError(
+            f"top_k ({top_k}) is larger than the number of samples ({n_samples})."
+        )
+    effective_k = min(top_k, n_samples)
+
+    if effective_k <= 0:
+        return None
+
+    top_k_gt_indices = set(np.argsort(gt_values)[-effective_k:])
+    top_k_pred_indices = set(np.argsort(pred_values)[-effective_k:])
+
+    overlap = len(top_k_gt_indices & top_k_pred_indices)
+    return overlap / effective_k
+
+
+def metric_spearman(
+    ground_truth: Subsets | Dataset,
+    predicted: Dataset,
+    target: str,
+    split: str | None = None,
+    fold: int | list[int] | None = None,
+) -> float:
+    """Compute the Spearman rank correlation between ground truth and predictions.
+
+    The Spearman correlation assesses how well the relationship between ground truth
+    and predicted values can be described using a monotonic function. It measures the
+    strength and direction of association between the ranked versions of the values.
+
+    This metric is rank-based and robust to outliers, making it suitable for
+    evaluating model predictions when the absolute scale matters less than the
+    relative ordering of samples.
+
+    Args:
+        ground_truth: The ground truth data, either as a complete Dataset or
+            a Subsets object containing dataset slices.
+        predicted: The predicted Dataset containing model predictions for the target.
+        target: The name of the target variable to score (e.g., 'fitness').
+        split: Required when ground_truth is a Subsets object. The name of the
+            splitting strategy to evaluate (e.g., 'random').
+        fold: Required when ground_truth is a Subsets object. The fold index
+            (0-based integer) within the specified split.
+
+    Returns:
+        The Spearman rank correlation coefficient, ranging from -1 to 1:
+            - 1.0 indicates a perfect positive monotonic relationship
+            - -1.0 indicates a perfect negative monotonic relationship
+            - 0.0 indicates no monotonic relationship
+
+    Raises:
+        TypeError: If ground_truth is neither a Dataset nor a Subsets object.
+        ValueError: If split or fold is None when ground_truth is a Subsets object.
+        ValueError: If any ground truth records lack corresponding predictions.
+    """
+    scoring_df = prepare_and_validate_scoring_df(
+        ground_truth, predicted, target, split, fold
+    )
+    gt_values = scoring_df[target].to_numpy()
+    pred_values = scoring_df[f"{target}_pred"].to_numpy()
+    spearman_corr, _ = spearmanr(gt_values, pred_values)
+    return spearman_corr
+
+
+def calculate_selected_metrics(
+    selected_metrics: list[str],
+    ground_truth: Subsets | Dataset,
+    predicted: Dataset,
+    target: str,
+    split: str | None = None,
+    fold: int | list[int] | None = None,
+) -> dict[str, float | None]:
+    """Calculate selected metrics by comparing ground truth and predictions.
+
+    This function dynamically discovers all functions with the ``metric_`` prefix in
+    this module and executes the requested ones. Each metric function receives the
+    ground truth, predictions, and scoring parameters.
+
+    Args:
+        selected_metrics: List of metric names to calculate (e.g., ["spearman"]).
+            Names should match the function suffix after ``metric_``.
+        ground_truth: The ground truth data, either as a complete Dataset or
+            a Subsets object containing dataset slices.
+        predicted: The predicted Dataset containing model predictions for the target.
+        target: The name of the target variable to score (e.g., 'fitness').
+        split: Required when ground_truth is a Subsets object. The name of the
+            splitting strategy to evaluate (e.g., 'random').
+        fold: Required when ground_truth is a Subsets object. The fold index
+            (0-based integer) within the specified split.
+
+    Returns:
+        Dictionary mapping metric names to their computed values. Some metrics (like
+        recovery) may return None when they cannot be calculated for a given dataset
+        slice (e.g., missing metadata). None values are preserved in the output and
+        will serialize as null in JSON.
+    """
+    metric_functions = _discover_metric_functions()
+    results: dict[str, float | None] = {}
+
+    for metric_name in selected_metrics:
+        if metric_name in metric_functions:
+            metric_value = metric_functions[metric_name](
+                ground_truth, predicted, target, split, fold
+            )
+            results[metric_name] = metric_value
+        else:
+            logger.warning(f"Metric '{metric_name}' not found in available metrics")
+
+    return results
+
+
+def calculate_metrics_by_mode(
+    selected_metrics: list[str],
+    ground_truth: Subsets,
+    predicted: Dataset,
+    target: str,
+    split: str,
+    test_fold: int,
+    score_modes: list[str] | None = None,
+) -> dict[str, Any]:
+    """Calculate metrics in different scoring modes.
+
+    Args:
+        selected_metrics: List of metric names to calculate (e.g., ["spearman"]).
+        ground_truth: The Subsets object containing cross-validation splits.
+        predicted: The predicted Dataset containing model predictions.
+        target: The name of the target variable to score.
+        split: The name of the splitting strategy (e.g., 'random', 'kfold_random').
+        test_fold: The fold index designated as the test fold.
+        score_modes: List of scoring modes. Options:
+            - "test": Score only the test fold
+            - "train_available": Score all non-test folds in aggregate
+            - "per_fold": Score each fold individually
+            - "full_dataset": Score against the full underlying dataset (ignoring
+              splits)
+            If None, defaults to ["test", "train_available", "per_fold"].
+
+    Returns:
+        Dictionary with structure::
+
+            {
+                "test": {"spearman": 0.85, ...},
+                "train_available": {"spearman": 0.92, ...},
+                "per_fold": {
+                    "fold_0": {"spearman": 0.91, ...},
+                    ...
+                },
+                "full_dataset": {"spearman": 0.83, ...},
+                "metadata": {
+                    "test_folds": [4],
+                    "train_available_folds": [0, 1, 2, 3],
+                    "total_folds": 5
+                }
+            }
+
+        When full_dataset mode is used, it scores against the complete dataset
+        ignoring all splits. The metric value is identical across all folds since it
+        evaluates the same data regardless of the fold.
+    """
+    if score_modes is None:
+        score_modes = ["test", "train_available", "per_fold"]
+
+    all_fold_indices = get_fold_indices(ground_truth, split)
+    train_folds = [f for f in all_fold_indices if f != test_fold]
+
+    results: dict[str, Any] = {}
+
+    if "test" in score_modes:
+        results["test"] = calculate_selected_metrics(
+            selected_metrics, ground_truth, predicted, target, split, test_fold
+        )
+
+    if "train_available" in score_modes:
+        results["train_available"] = calculate_selected_metrics(
+            selected_metrics, ground_truth, predicted, target, split, train_folds
+        )
+
+    if "per_fold" in score_modes:
+        per_fold: dict[str, dict[str, float | None]] = {}
+        for fold_idx in all_fold_indices:
+            per_fold[f"fold_{fold_idx}"] = calculate_selected_metrics(
+                selected_metrics, ground_truth, predicted, target, split, fold_idx
+            )
+        results["per_fold"] = per_fold
+
+    if "full_dataset" in score_modes:
+        results["full_dataset"] = calculate_selected_metrics(
+            selected_metrics, ground_truth.dataset, predicted, target, None, None
+        )
+
+    results["metadata"] = {
+        "test_folds": [test_fold],
+        "train_available_folds": train_folds,
+        "total_folds": len(all_fold_indices),
+    }
+
+    return results
+
+
+def evaluate(
+    prediction_path: Path,
+    metric_path: Path,
+    dataset_path: Path | None = None,
+    selected_metrics: list[str] | None = None,
+    model_name: str | None = None,
+    split: str | None = None,
+    target: str | None = None,
+    fold: str | None = None,
+    score_modes: list[str] | None = None,
+) -> Path:
+    """Calculate performance metrics from predictions and save results to JSON.
+
+    Loads ground truth data from a dataset archive (.pgdata or .splits.pgdata),
+    loads predictions from a prediction archive, calculates the selected metrics,
+    and saves the results to a JSON file with metadata.
+
+    The function automatically detects whether the dataset is a plain Dataset
+    (.pgdata) or Subsets (.splits.pgdata) based on the file extension.
+
+    If the prediction file is not found, an error JSON with null metric values
+    is written instead.
+
+    Args:
+        prediction_path: Path to the prediction dataset archive (.pgdata file)
+            containing model predictions.
+        metric_path: Path where the calculated metrics JSON will be saved.
+        dataset_path: Path to the ground truth dataset archive. Can be either:
+            - .pgdata file: Plain Dataset for single-fold scoring
+            - .splits.pgdata file: Subsets with cross-validation splits
+        selected_metrics: Optional list of metric names to calculate (e.g.,
+            ["spearman"]). If None, all discovered metrics are included.
+        model_name: Name of the model that generated predictions (stored in metadata).
+        split: Name of the splitting strategy to evaluate (e.g., 'random'). Required
+            when dataset_path is a .splits.pgdata file.
+        target: Name of the target variable to score (e.g., 'DMS_score', 'fitness').
+            Required for all metric calculations.
+        fold: Fold index (as string) designated as the test fold. Required when
+            dataset_path is a .splits.pgdata file.
+        score_modes: List of scoring modes. Options: "test", "train_available",
+            "per_fold", "full_dataset". If None, defaults to
+            ["test", "train_available", "per_fold"]. Only used when dataset_path is a
+            .splits.pgdata file.
+
+    Returns:
+        The path to the saved metrics JSON file (same as metric_path input).
+
+    Raises:
+        ValueError: If required parameters (--split, --fold, --target) are missing for
+            a Subsets file, or if --target is missing for a plain Dataset.
+    """
+    logger.info("Start to calculate metrics.")
+
+    if not prediction_path.exists():
+        logger.error(f"Prediction file not found: {prediction_path}")
+        error_result: dict[str, Any] = {
+            "error": f"Prediction file not found: {prediction_path}",
+            "status": "failed",
+        }
+
+        if selected_metrics:
+            for metric_name in selected_metrics:
+                error_result[metric_name] = None
+
+        metric_path.write_text(json.dumps(error_result, indent=2))
+        return metric_path
+
+    if dataset_path is None:
+        raise ValueError(
+            "The 'dataset_path' parameter is required for metric calculation."
+        )
+
+    metrics_to_calculate = selected_metrics or list(_discover_metric_functions())
+
+    try:
+        if dataset_path.name.endswith(".splits.pgdata"):
+            ground_truth: Dataset | Subsets = Subsets.from_path(dataset_path)
+        else:
+            ground_truth = Dataset.from_path(dataset_path)
+    except (FileNotFoundError, ValueError) as e:
+        logger.error(f"Failed to load dataset from {dataset_path}: {e}")
+        raise
+
+    try:
+        predicted = Dataset.from_path(prediction_path)
+    except (FileNotFoundError, ValueError) as e:
+        logger.error(f"Failed to load predictions from {prediction_path}: {e}")
+        raise
+
+    test_fold: int | None = None
+    metrics_result: dict[str, Any]
+    if isinstance(ground_truth, Subsets):
+        if split is None or fold is None or target is None:
+            raise ValueError(
+                "Parameters --split, --fold, and --target are required when "
+                "dataset_path is a Subsets file (.splits.pgdata)."
+            )
+
+        test_fold = int(fold)
+
+        metrics_result = calculate_metrics_by_mode(
+            metrics_to_calculate,
+            ground_truth,
+            predicted,
+            target,
+            split,
+            test_fold,
+            score_modes,
+        )
+    else:
+        if target is None:
+            raise ValueError(
+                "The 'target' parameter is required for metric calculation. "
+                "Please provide --target."
+            )
+
+        metrics_result = {
+            "full_dataset": calculate_selected_metrics(
+                metrics_to_calculate, ground_truth, predicted, target, None, None
+            )
+        }
+
+    dataset_name = dataset_path.stem
+    if any([dataset_name, model_name, split, target, fold]):
+        if "metadata" not in metrics_result:
+            metrics_result["metadata"] = {}
+        if dataset_name:
+            metrics_result["metadata"]["dataset"] = dataset_name
+        if model_name:
+            metrics_result["metadata"]["model"] = model_name
+        if split:
+            metrics_result["metadata"]["split"] = split
+        if target:
+            metrics_result["metadata"]["target"] = target
+        if fold:
+            metrics_result["metadata"]["test_fold"] = test_fold
+
+    metric_path.parent.mkdir(parents=True, exist_ok=True)
+    metric_path.write_text(json.dumps(metrics_result, indent=2))
+    return metric_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,79 @@
+import json
 from pathlib import Path
 
+import polars as pl
+from Bio.Seq import Seq
 from typer.testing import CliRunner
 
 from proteingym.base.__about__ import __version__
 from proteingym.base.__main__ import app
+from proteingym.base.dataset import Assay, Dataset, Field
+from proteingym.base.sequence import Sequence, SequenceAlphabet, SequenceType
+
+
+def _build_dataset() -> Dataset:
+    """Build a small in-memory dataset with a single assay of 10 records."""
+    sequences = [
+        Sequence(
+            name=f"seq{i}",
+            value=Seq(seq_value),
+            type=SequenceType.ENGINEERED_SEQUENCE,
+            alphabet=SequenceAlphabet.AA,
+        )
+        for i, seq_value in enumerate(
+            [
+                "ACDEFG",
+                "ACDEFH",
+                "ACDEFI",
+                "ACDEFK",
+                "ACDEFL",
+                "ACDEFM",
+                "ACDEFN",
+                "ACDEFP",
+                "ACDEFQ",
+                "ACDEFR",
+            ]
+        )
+    ]
+
+    assay = Assay(
+        name="assay1",
+        records=[(sequences[i], float(i + 1)) for i in range(10)],
+        fields=[Field(name="sequence"), Field(name="DMS Score")],
+    )
+
+    return Dataset(
+        name="cli_test_dataset",
+        description="A dataset for CLI evaluate tests.",
+        assay_variables=[],
+        assay_targets=[Field(name="DMS Score", description="The DMS score")],
+        assays=[assay],
+        sequences=[],
+        structures=[],
+        msas=[],
+    )
+
+
+def _build_predictions(dataset: Dataset) -> Dataset:
+    """Build a predictions dataset from the ground truth dataset."""
+    predictions_df = pl.DataFrame(
+        {
+            "sequence": [
+                "ACDEFG",
+                "ACDEFH",
+                "ACDEFI",
+                "ACDEFK",
+                "ACDEFL",
+                "ACDEFM",
+                "ACDEFN",
+                "ACDEFP",
+                "ACDEFQ",
+                "ACDEFR",
+            ],
+            "DMS Score": [1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1, 9.1, 10.1],
+        }
+    )
+    return dataset.predictions_delta(predictions_df, target="DMS Score")
 
 
 def test_cli_callback() -> None:
@@ -81,3 +151,82 @@ def test_build_command_with_output_path(tmp_path: Path) -> None:
         app, ["build", manifest.as_posix(), "--output-path", output_dir.as_posix()]
     )
     assert (output_dir / f"{dataset_name}.pgdata").as_posix() in result.stdout
+
+
+def test_evaluate_command_help() -> None:
+    """Evaluate command shows help message when --help is used."""
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["evaluate", "--help"])
+
+    assert result.exit_code == 0
+    assert "--prediction-path" in result.stdout
+    assert "--metric-path" in result.stdout
+    assert "--selected-metrics" in result.stdout
+    assert "--score-modes" in result.stdout
+
+
+def test_evaluate_command_full_dataset(tmp_path: Path) -> None:
+    """Evaluate command computes metrics for a plain dataset."""
+
+    dataset = _build_dataset()
+    predictions = _build_predictions(dataset)
+
+    dataset_path = dataset.dump(path=tmp_path)
+    prediction_path = predictions.dump(path=tmp_path)
+    metric_path = tmp_path / "metrics.json"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "evaluate",
+            "--prediction-path",
+            prediction_path.as_posix(),
+            "--metric-path",
+            metric_path.as_posix(),
+            "--dataset-path",
+            dataset_path.as_posix(),
+            "--target",
+            "DMS Score",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert metric_path.exists()
+    metrics_result = json.loads(metric_path.read_text())
+    assert "spearman" in metrics_result["full_dataset"]
+
+
+def test_evaluate_command_repeated_metric_flags(tmp_path: Path) -> None:
+    """Evaluate command accepts repeated --selected-metrics flags."""
+
+    dataset = _build_dataset()
+    predictions = _build_predictions(dataset)
+
+    dataset_path = dataset.dump(path=tmp_path)
+    prediction_path = predictions.dump(path=tmp_path)
+    metric_path = tmp_path / "metrics.json"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "evaluate",
+            "--prediction-path",
+            prediction_path.as_posix(),
+            "--metric-path",
+            metric_path.as_posix(),
+            "--dataset-path",
+            dataset_path.as_posix(),
+            "--target",
+            "DMS Score",
+            "--selected-metrics",
+            "spearman",
+            "--selected-metrics",
+            "recovery",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert metric_path.exists()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,780 @@
+import json
+import logging
+
+import polars as pl
+import pytest
+from Bio.Seq import Seq
+
+from proteingym.base.assay import SEQUENCE
+from proteingym.base.dataset import (
+    Assay,
+    AssaySlice,
+    Dataset,
+    DatasetSlice,
+    Field,
+    Subsets,
+)
+from proteingym.base.metrics import (
+    _get_top_k_from_slice,
+    calculate_metrics_by_mode,
+    calculate_selected_metrics,
+    evaluate,
+    metric_recovery,
+    metric_spearman,
+    prepare_and_validate_scoring_df,
+)
+from proteingym.base.sequence import Sequence, SequenceAlphabet, SequenceType
+
+
+@pytest.fixture
+def metrics_dataset_with_assay() -> Dataset:
+    """A dataset containing a single assay with 10 records."""
+    sequences = [
+        Sequence(
+            name=f"seq{i}",
+            value=Seq(seq_value),
+            type=SequenceType.ENGINEERED_SEQUENCE,
+            alphabet=SequenceAlphabet.AA,
+        )
+        for i, seq_value in enumerate(
+            [
+                "ACDEFG",
+                "ACDEFH",
+                "ACDEFI",
+                "ACDEFK",
+                "ACDEFL",
+                "ACDEFM",
+                "ACDEFN",
+                "ACDEFP",
+                "ACDEFQ",
+                "ACDEFR",
+            ],
+            start=1,
+        )
+    ]
+
+    assay = Assay(
+        name="assay1",
+        records=[(sequences[i], float(i + 1), float(i + 1) + 0.5) for i in range(10)],
+        fields=[
+            Field(name="sequence"),
+            Field(name="DMS Score"),
+            Field(name="stability"),
+        ],
+    )
+    return Dataset(
+        name="dataset_with_single_assay",
+        description="A dataset containing a single assay.",
+        assay_variables=[Field(name="var1", description="A test variable")],
+        assay_targets=[
+            Field(name="DMS Score", description="The DMS score"),
+            Field(name="stability", description="The resistance to temperature"),
+        ],
+        assays=[assay],
+        sequences=[],
+        structures=[],
+        msas=[],
+    )
+
+
+@pytest.fixture
+def metrics_predicted_dataset(metrics_dataset_with_assay: Dataset) -> Dataset:
+    """A predictions dataset built from metrics_dataset_with_assay."""
+    predictions_df = pl.DataFrame(
+        {
+            "sequence": [
+                "ACDEFG",
+                "ACDEFH",
+                "ACDEFI",
+                "ACDEFK",
+                "ACDEFL",
+                "ACDEFM",
+                "ACDEFN",
+                "ACDEFP",
+                "ACDEFQ",
+                "ACDEFR",
+            ],
+            "DMS Score": [1.1, 2.1, 3.1, 4.1, 5.1, 6.1, 7.1, 8.1, 9.1, 10.1],
+        }
+    )
+    return metrics_dataset_with_assay.predictions_delta(
+        predictions_df, target="DMS Score"
+    )
+
+
+@pytest.fixture
+def metrics_subsets_with_assays(metrics_dataset_with_assay: Dataset) -> Subsets:
+    """A Subsets object with a 5-fold 'random' split (2 records per fold)."""
+    folds = []
+    for fold_idx in range(5):
+        records_mask = [False] * 10
+        records_mask[fold_idx * 2] = True
+        records_mask[fold_idx * 2 + 1] = True
+
+        fold_slice = DatasetSlice(
+            assays=[AssaySlice(records=records_mask)],
+            metadata={"fold": float(fold_idx)},
+        )
+        folds.append(fold_slice)
+
+    return Subsets(dataset=metrics_dataset_with_assay, slices={"random": folds})
+
+
+@pytest.fixture
+def recovery_dataset() -> Dataset:
+    """A dataset with known values for testing recovery."""
+    sequences = [
+        Sequence(
+            name=f"seq{i}",
+            value=Seq(f"SEQ{i:03d}"),
+            type=SequenceType.ENGINEERED_SEQUENCE,
+            alphabet=SequenceAlphabet.AA,
+        )
+        for i in range(10)
+    ]
+
+    assay = Assay(
+        name="assay1",
+        records=[(sequences[i], (i + 1) / 10.0) for i in range(10)],
+        fields=[
+            Field(name="sequence"),
+            Field(name="fitness"),
+        ],
+    )
+
+    return Dataset(
+        name="recovery_test",
+        description="Dataset for recovery testing",
+        assay_variables=[],
+        assay_targets=[Field(name="fitness", description="Fitness score")],
+        assays=[assay],
+        sequences=sequences,
+        structures=[],
+        msas=[],
+    )
+
+
+@pytest.fixture
+def recovery_subsets(recovery_dataset: Dataset) -> Subsets:
+    """Subsets with top_k metadata covering all records in a single slice."""
+    all_records_mask = [True] * 10
+    return Subsets(
+        dataset=recovery_dataset,
+        slices={
+            "test": [
+                DatasetSlice(
+                    assays=[AssaySlice(records=all_records_mask)],
+                    metadata={"top_k": 3},
+                )
+            ]
+        },
+    )
+
+
+def _fitness_predictions(recovery_dataset: Dataset, values: list[float]) -> Dataset:
+    """Helper to build a fitness predictions dataset."""
+    predictions_df = pl.DataFrame(
+        {
+            "sequence": [f"SEQ{i:03d}" for i in range(10)],
+            "fitness": values,
+        }
+    )
+    return recovery_dataset.predictions_delta(predictions_df, target="fitness")
+
+
+class TestMetricSpearman:
+    """Test metric_spearman function."""
+
+    def test_perfect_correlation(self, metrics_dataset_with_assay):
+        perfect_predictions_df = pl.DataFrame(
+            {
+                "sequence": [
+                    "ACDEFG",
+                    "ACDEFH",
+                    "ACDEFI",
+                    "ACDEFK",
+                    "ACDEFL",
+                    "ACDEFM",
+                    "ACDEFN",
+                    "ACDEFP",
+                    "ACDEFQ",
+                    "ACDEFR",
+                ],
+                "DMS Score": [10.0 * (i + 1) for i in range(10)],
+            }
+        )
+
+        perfect_preds = metrics_dataset_with_assay.predictions_delta(
+            perfect_predictions_df, target="DMS Score"
+        )
+
+        corr = metric_spearman(
+            ground_truth=metrics_dataset_with_assay,
+            predicted=perfect_preds,
+            target="DMS Score",
+        )
+
+        assert corr == pytest.approx(1.0)
+
+    def test_realistic_correlation(
+        self, metrics_dataset_with_assay, metrics_predicted_dataset
+    ):
+        corr = metric_spearman(
+            ground_truth=metrics_dataset_with_assay,
+            predicted=metrics_predicted_dataset,
+            target="DMS Score",
+        )
+
+        assert isinstance(corr, float)
+        assert -1.0 <= corr <= 1.0
+
+
+class TestGetTopKFromSlice:
+    """Test _get_top_k_from_slice helper function."""
+
+    @pytest.fixture
+    def simple_dataset(self) -> Dataset:
+        return Dataset(
+            name="test",
+            assay_targets=[Field(name="target")],
+            assay_variables=[],
+            assays=[],
+        )
+
+    def test_returns_none_for_dataset(self, simple_dataset):
+        assert (
+            _get_top_k_from_slice(ground_truth=simple_dataset, split="test", fold=0)
+            is None
+        )
+
+    def test_returns_none_without_split(self, simple_dataset):
+        subsets = Subsets(
+            dataset=simple_dataset,
+            slices={"test": [DatasetSlice(metadata={"top_k": 10})]},
+        )
+        assert _get_top_k_from_slice(ground_truth=subsets, split=None, fold=0) is None
+
+    def test_returns_none_without_fold(self, simple_dataset):
+        subsets = Subsets(
+            dataset=simple_dataset,
+            slices={"test": [DatasetSlice(metadata={"top_k": 10})]},
+        )
+        assert (
+            _get_top_k_from_slice(ground_truth=subsets, split="test", fold=None) is None
+        )
+
+    def test_returns_none_for_list_fold(self, simple_dataset):
+        subsets = Subsets(
+            dataset=simple_dataset,
+            slices={"test": [DatasetSlice(metadata={"top_k": 10})]},
+        )
+        assert (
+            _get_top_k_from_slice(ground_truth=subsets, split="test", fold=[0, 1])
+            is None
+        )
+
+    def test_returns_none_without_metadata(self, simple_dataset):
+        subsets = Subsets(
+            dataset=simple_dataset, slices={"test": [DatasetSlice(metadata=None)]}
+        )
+        assert _get_top_k_from_slice(ground_truth=subsets, split="test", fold=0) is None
+
+    def test_returns_none_without_top_k_in_metadata(self, simple_dataset):
+        subsets = Subsets(
+            dataset=simple_dataset,
+            slices={"test": [DatasetSlice(metadata={"other_key": "value"})]},
+        )
+        assert _get_top_k_from_slice(ground_truth=subsets, split="test", fold=0) is None
+
+    def test_extracts_top_k_successfully(self, simple_dataset):
+        subsets = Subsets(
+            dataset=simple_dataset,
+            slices={"test": [DatasetSlice(metadata={"top_k": 10})]},
+        )
+        assert _get_top_k_from_slice(ground_truth=subsets, split="test", fold=0) == 10
+
+    def test_converts_float_top_k_to_int(self, simple_dataset):
+        subsets = Subsets(
+            dataset=simple_dataset,
+            slices={"test": [DatasetSlice(metadata={"top_k": 10.0})]},
+        )
+        result = _get_top_k_from_slice(ground_truth=subsets, split="test", fold=0)
+        assert result == 10
+        assert isinstance(result, int)
+
+
+class TestMetricRecovery:
+    """Test metric_recovery function."""
+
+    def test_perfect_recovery(self, recovery_subsets):
+        predictions = _fitness_predictions(
+            recovery_subsets.dataset, [(i + 1) / 10.0 for i in range(10)]
+        )
+        recovery = metric_recovery(
+            ground_truth=recovery_subsets,
+            predicted=predictions,
+            target="fitness",
+            split="test",
+            fold=0,
+        )
+        assert recovery == pytest.approx(1.0)
+
+    def test_zero_recovery(self, recovery_subsets):
+        predictions = _fitness_predictions(
+            recovery_subsets.dataset, [(10 - i) / 10.0 for i in range(10)]
+        )
+        recovery = metric_recovery(
+            ground_truth=recovery_subsets,
+            predicted=predictions,
+            target="fitness",
+            split="test",
+            fold=0,
+        )
+        assert recovery == pytest.approx(0.0)
+
+    def test_partial_recovery(self, recovery_subsets):
+        predictions = _fitness_predictions(
+            recovery_subsets.dataset,
+            [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.95, 0.75, 0.9, 1.0],
+        )
+        recovery = metric_recovery(
+            ground_truth=recovery_subsets,
+            predicted=predictions,
+            target="fitness",
+            split="test",
+            fold=0,
+        )
+        assert recovery == pytest.approx(2.0 / 3.0)
+
+    def test_recovery_with_dataset_returns_none(self, recovery_dataset):
+        predictions = _fitness_predictions(
+            recovery_dataset, [(i + 1) / 10.0 for i in range(10)]
+        )
+        recovery = metric_recovery(
+            ground_truth=recovery_dataset,
+            predicted=predictions,
+            target="fitness",
+        )
+        assert recovery is None
+
+    def test_recovery_without_metadata_returns_none(self, recovery_dataset):
+        subsets_no_metadata = Subsets(
+            dataset=recovery_dataset, slices={"test": [DatasetSlice(metadata=None)]}
+        )
+        predictions = _fitness_predictions(
+            recovery_dataset, [(i + 1) / 10.0 for i in range(10)]
+        )
+        recovery = metric_recovery(
+            ground_truth=subsets_no_metadata,
+            predicted=predictions,
+            target="fitness",
+            split="test",
+            fold=0,
+        )
+        assert recovery is None
+
+    def test_recovery_in_calculate_selected_metrics(self, recovery_subsets):
+        predictions = _fitness_predictions(
+            recovery_subsets.dataset, [(i + 1) / 10.0 for i in range(10)]
+        )
+        results = calculate_selected_metrics(
+            selected_metrics=["recovery", "spearman"],
+            ground_truth=recovery_subsets,
+            predicted=predictions,
+            target="fitness",
+            split="test",
+            fold=0,
+        )
+        assert "recovery" in results and "spearman" in results
+        assert results["recovery"] == pytest.approx(1.0)
+        assert results["spearman"] == pytest.approx(1.0)
+
+    def test_recovery_none_for_training_folds(self, recovery_dataset):
+        half_records_mask = [i < 5 for i in range(10)]
+        subsets_with_mixed_metadata = Subsets(
+            dataset=recovery_dataset,
+            slices={
+                "test": [
+                    DatasetSlice(
+                        assays=[AssaySlice(records=half_records_mask)],
+                        metadata={"top_k": 2},
+                    ),
+                    DatasetSlice(
+                        assays=[AssaySlice(records=half_records_mask)], metadata=None
+                    ),
+                ]
+            },
+        )
+        predictions = _fitness_predictions(
+            recovery_dataset, [(i + 1) / 10.0 for i in range(10)]
+        )
+
+        test_recovery = metric_recovery(
+            ground_truth=subsets_with_mixed_metadata,
+            predicted=predictions,
+            target="fitness",
+            split="test",
+            fold=0,
+        )
+        assert test_recovery == pytest.approx(1.0)
+
+        train_recovery = metric_recovery(
+            ground_truth=subsets_with_mixed_metadata,
+            predicted=predictions,
+            target="fitness",
+            split="test",
+            fold=1,
+        )
+        assert train_recovery is None
+
+    def test_recovery_in_calculate_metrics_by_mode(self, recovery_dataset):
+        all_records_mask = [True] * 10
+        subsets = Subsets(
+            dataset=recovery_dataset,
+            slices={
+                "cv": [
+                    DatasetSlice(
+                        assays=[AssaySlice(records=all_records_mask)], metadata=None
+                    ),
+                    DatasetSlice(
+                        assays=[AssaySlice(records=all_records_mask)], metadata=None
+                    ),
+                    DatasetSlice(
+                        assays=[AssaySlice(records=all_records_mask)],
+                        metadata={"top_k": 3},
+                    ),
+                ]
+            },
+        )
+        predictions = _fitness_predictions(
+            recovery_dataset, [(i + 1) / 10.0 for i in range(10)]
+        )
+
+        results = calculate_metrics_by_mode(
+            selected_metrics=["recovery", "spearman"],
+            ground_truth=subsets,
+            predicted=predictions,
+            target="fitness",
+            split="cv",
+            test_fold=2,
+        )
+
+        expected_structure = {
+            "test_has_recovery": results["test"]["recovery"] == pytest.approx(1.0),
+            "test_has_spearman": results["test"]["spearman"] == pytest.approx(1.0),
+            "train_recovery_is_none": results["train_available"]["recovery"] is None,
+            "train_has_spearman": results["train_available"]["spearman"]
+            == pytest.approx(1.0),
+            "fold_0_recovery_is_none": results["per_fold"]["fold_0"]["recovery"]
+            is None,
+            "fold_1_recovery_is_none": results["per_fold"]["fold_1"]["recovery"]
+            is None,
+            "fold_2_has_recovery": results["per_fold"]["fold_2"]["recovery"]
+            == pytest.approx(1.0),
+        }
+
+        assert all(expected_structure.values()), (
+            f"Failed checks: {[k for k, v in expected_structure.items() if not v]}"
+        )
+
+    def test_recovery_none_serializes_to_json_null(self, recovery_dataset):
+        all_records_mask = [True] * 10
+        subsets = Subsets(
+            dataset=recovery_dataset,
+            slices={
+                "cv": [
+                    DatasetSlice(
+                        assays=[AssaySlice(records=all_records_mask)], metadata=None
+                    ),
+                    DatasetSlice(
+                        assays=[AssaySlice(records=all_records_mask)],
+                        metadata={"top_k": 3},
+                    ),
+                ]
+            },
+        )
+        predictions = _fitness_predictions(
+            recovery_dataset, [(i + 1) / 10.0 for i in range(10)]
+        )
+
+        results = calculate_metrics_by_mode(
+            selected_metrics=["recovery", "spearman"],
+            ground_truth=subsets,
+            predicted=predictions,
+            target="fitness",
+            split="cv",
+            test_fold=1,
+        )
+
+        json_str = json.dumps(results)
+        parsed = json.loads(json_str)
+
+        expected_json_structure = {
+            "test_recovery_is_float": isinstance(parsed["test"]["recovery"], float),
+            "train_recovery_is_null": parsed["train_available"]["recovery"] is None,
+            "fold_0_recovery_is_null": parsed["per_fold"]["fold_0"]["recovery"] is None,
+            "fold_1_recovery_is_float": isinstance(
+                parsed["per_fold"]["fold_1"]["recovery"], float
+            ),
+            "json_contains_null_string": '"recovery": null' in json_str,
+        }
+
+        assert all(expected_json_structure.values()), (
+            f"Failed checks: {[k for k, v in expected_json_structure.items() if not v]}"
+        )
+
+    def test_top_k_larger_than_samples_raises_error(self, recovery_dataset):
+        predictions_df = pl.DataFrame(
+            {
+                "sequence": ["SEQ000", "SEQ001"],
+                "fitness": [0.1, 0.2],
+            }
+        )
+        predicted = recovery_dataset.predictions_delta(predictions_df, target="fitness")
+
+        records_mask = [i < 2 for i in range(10)]
+        fold_slice = DatasetSlice(
+            assays=[AssaySlice(records=records_mask)],
+            metadata={"top_k": 10},
+        )
+        subsets = Subsets(dataset=recovery_dataset, slices={"test": [fold_slice]})
+
+        with pytest.raises(
+            ValueError,
+            match=r"top_k \(10\) is larger than the number of samples \(2\)\.",
+        ):
+            metric_recovery(
+                ground_truth=subsets,
+                predicted=predicted,
+                target="fitness",
+                split="test",
+                fold=0,
+            )
+
+
+class TestPrepareAndValidateScoringDf:
+    """Test prepare_and_validate_scoring_df function."""
+
+    def test_with_dataset(self, metrics_dataset_with_assay, metrics_predicted_dataset):
+        df = prepare_and_validate_scoring_df(
+            ground_truth=metrics_dataset_with_assay,
+            predicted=metrics_predicted_dataset,
+            target="DMS Score",
+        )
+
+        expected_properties = {
+            "is_dataframe": isinstance(df, pl.DataFrame),
+            "has_sequence": SEQUENCE in df.columns,
+            "has_target": "DMS Score" in df.columns,
+            "has_predictions": "DMS Score_pred" in df.columns,
+            "correct_length": len(df) == 10,
+        }
+
+        assert all(expected_properties.values()), (
+            f"Failed checks: {[k for k, v in expected_properties.items() if not v]}"
+        )
+
+    def test_missing_predictions_raises_error(self, metrics_dataset_with_assay):
+        incomplete_predictions_df = pl.DataFrame(
+            {
+                "sequence": ["ACDEFG"],
+                "DMS Score": [1.1],
+            }
+        )
+        incomplete_preds = metrics_dataset_with_assay.predictions_delta(
+            incomplete_predictions_df, target="DMS Score"
+        )
+
+        with pytest.raises(ValueError, match="Missing 9 prediction"):
+            prepare_and_validate_scoring_df(
+                ground_truth=metrics_dataset_with_assay,
+                predicted=incomplete_preds,
+                target="DMS Score",
+            )
+
+    def test_invalid_ground_truth_type_raises_error(self, metrics_predicted_dataset):
+        with pytest.raises(TypeError, match="must be a Dataset or a Subsets object"):
+            prepare_and_validate_scoring_df(
+                ground_truth="invalid",  # type: ignore
+                predicted=metrics_predicted_dataset,
+                target="fitness",
+            )
+
+    def test_subsets_without_split_raises_error(
+        self, metrics_subsets_with_assays, metrics_predicted_dataset
+    ):
+        with pytest.raises(
+            ValueError, match="Both 'split' and 'fold' must be provided"
+        ):
+            prepare_and_validate_scoring_df(
+                ground_truth=metrics_subsets_with_assays,
+                predicted=metrics_predicted_dataset,
+                target="DMS Score",
+            )
+
+
+class TestCalculateSelectedMetrics:
+    """Test calculate_selected_metrics function."""
+
+    def test_calculate_single_metric(
+        self, metrics_dataset_with_assay, metrics_predicted_dataset
+    ):
+        results = calculate_selected_metrics(
+            selected_metrics=["spearman"],
+            ground_truth=metrics_dataset_with_assay,
+            predicted=metrics_predicted_dataset,
+            target="DMS Score",
+        )
+
+        expected_result = {
+            "is_dict": isinstance(results, dict),
+            "has_spearman": "spearman" in results,
+            "spearman_is_float": isinstance(results.get("spearman"), float),
+        }
+
+        assert all(expected_result.values()), (
+            f"Failed checks: {[k for k, v in expected_result.items() if not v]}"
+        )
+
+    def test_unknown_metric_warning(
+        self, metrics_dataset_with_assay, metrics_predicted_dataset, caplog
+    ):
+        with caplog.at_level(logging.WARNING, logger="proteingym.base"):
+            results = calculate_selected_metrics(
+                selected_metrics=["unknown_metric"],
+                ground_truth=metrics_dataset_with_assay,
+                predicted=metrics_predicted_dataset,
+                target="DMS Score",
+            )
+
+        assert "Metric 'unknown_metric' not found" in caplog.text
+        assert "unknown_metric" not in results
+
+
+class TestMetricsIntegration:
+    """Integration tests using real dataset fixtures."""
+
+    def test_with_subsets(self, metrics_subsets_with_assays):
+        dataset = metrics_subsets_with_assays.dataset
+        target_name = dataset.assay_targets[0].name
+
+        predictions = Dataset(
+            name="test_predictions",
+            assay_targets=dataset.assay_targets,
+            assay_variables=dataset.assay_variables,
+            assays=dataset.assays,
+        )
+
+        split_name = list(metrics_subsets_with_assays.slices.keys())[0]
+
+        results = calculate_selected_metrics(
+            selected_metrics=["spearman"],
+            ground_truth=metrics_subsets_with_assays,
+            predicted=predictions,
+            target=target_name,
+            split=split_name,
+            fold=0,
+        )
+
+        assert "spearman" in results
+        assert results["spearman"] == pytest.approx(1.0)
+
+    def test_multi_mode_scoring(self, metrics_subsets_with_assays):
+        dataset = metrics_subsets_with_assays.dataset
+        target_name = dataset.assay_targets[0].name
+
+        predictions = Dataset(
+            name="test_predictions",
+            assay_targets=dataset.assay_targets,
+            assay_variables=dataset.assay_variables,
+            assays=dataset.assays,
+        )
+
+        split_name = list(metrics_subsets_with_assays.slices.keys())[0]
+        test_fold = 0
+
+        results = calculate_metrics_by_mode(
+            selected_metrics=["spearman"],
+            ground_truth=metrics_subsets_with_assays,
+            predicted=predictions,
+            target=target_name,
+            split=split_name,
+            test_fold=test_fold,
+            score_modes=["test", "train_available", "per_fold"],
+        )
+
+        expected_results = {
+            "has_correct_keys": set(results.keys())
+            == {"test", "train_available", "per_fold", "metadata"},
+            "test_spearman_correct": results["test"]["spearman"] == pytest.approx(1.0),
+            "train_available_spearman_correct": results["train_available"]["spearman"]
+            == pytest.approx(1.0),
+            "per_fold_spearman_correct": all(
+                fold_metrics["spearman"] == pytest.approx(1.0)
+                for fold_metrics in results["per_fold"].values()
+            ),
+            "metadata_test_folds_correct": results["metadata"]["test_folds"]
+            == [test_fold],
+            "metadata_train_folds_correct": test_fold
+            not in results["metadata"]["train_available_folds"],
+            "metadata_total_folds_correct": results["metadata"]["total_folds"]
+            == len(results["per_fold"]),
+        }
+
+        assert all(expected_results.values()), (
+            f"Failed checks: {[k for k, v in expected_results.items() if not v]}"
+        )
+
+
+class TestEvaluateValidation:
+    """Test validation in the evaluate function."""
+
+    @pytest.mark.parametrize(
+        "split,fold,target",
+        [
+            ("split_name", "0", None),
+            (None, "0", "target_name"),
+            ("split_name", None, "target_name"),
+        ],
+    )
+    def test_evaluate_requires_parameters_for_subsets(
+        self, tmp_path, metrics_subsets_with_assays, split, fold, target
+    ):
+        metric_path = tmp_path / "metrics.json"
+
+        dataset_path = metrics_subsets_with_assays.dump(path=tmp_path)
+        pred_path = metrics_subsets_with_assays.dataset.dump(path=tmp_path)
+        target_name = metrics_subsets_with_assays.dataset.assay_targets[0].name
+        split_name = list(metrics_subsets_with_assays.slices.keys())[0]
+
+        split_value = split_name if split == "split_name" else split
+        target_value = target_name if target == "target_name" else target
+
+        with pytest.raises(
+            ValueError, match="--split, --fold, and --target are required"
+        ):
+            evaluate(
+                prediction_path=pred_path,
+                metric_path=metric_path,
+                dataset_path=dataset_path,
+                split=split_value,
+                fold=fold,
+                target=target_value,
+            )
+
+    def test_evaluate_missing_prediction_file_writes_error(self, tmp_path):
+        metric_path = tmp_path / "metrics.json"
+        missing_pred = tmp_path / "does_not_exist.pgdata"
+
+        result_path = evaluate(
+            prediction_path=missing_pred,
+            metric_path=metric_path,
+            dataset_path=tmp_path / "dataset.pgdata",
+            selected_metrics=["spearman"],
+            target="DMS Score",
+        )
+
+        assert result_path == metric_path
+        result = json.loads(metric_path.read_text())
+        assert result["status"] == "failed"
+        assert result["spearman"] is None

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -1724,6 +1724,7 @@ dependencies = [
     { name = "python-frontmatter" },
     { name = "requests" },
     { name = "scikit-learn" },
+    { name = "scipy" },
     { name = "semver" },
     { name = "toml" },
     { name = "typer" },
@@ -1759,6 +1760,7 @@ requires-dist = [
     { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "scikit-learn", specifier = ">=1.5.0,<2.0.0" },
+    { name = "scipy", specifier = ">=1.16.2,<2.0.0" },
     { name = "semver", specifier = ">=3.0.4,<4.0.0" },
     { name = "toml", specifier = ">=0.10.2,<1.0.0" },
     { name = "typer", specifier = ">=0.16.0,<1.0.0" },


### PR DESCRIPTION
Migrate metric calculation, plugin-style discovery, and scoring helpers from proteingym-benchmark into base so the logic is testable and shared, keeping DVC pipeline glue in the benchmark repo. Exposes evaluate, calculate_selected_metrics, and calculate_metrics_by_mode as public API.

Resolves 204 in Benchmark

# Checklist

- [x] I broke the PR down so that it contains a reasonable amount of changes for an effective review
- [x] I performed a self-review of my code. Amongst other things, I have commented my code in hard-to-understand areas.
- [x] I made corresponding changes to the documentation
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I accounted for dependent changes to be merged and published in downstream modules
